### PR TITLE
Features/add change status modal

### DIFF
--- a/src/libs/Helper.ts
+++ b/src/libs/Helper.ts
@@ -1,4 +1,6 @@
-import { moment } from "obsidian";
+import { TFile, moment } from "obsidian";
+import Global from "src/classes/Global";
+import { FileType } from "src/types/PrjTypes";
 
 export default class Helper {
     private static md5 = require('crypto-js/md5');
@@ -126,8 +128,30 @@ export default class Helper {
         );
     }
 
+    /**
+     * Checks if the given file type is valid.
+     * @param fileType The file type to check.
+     * @returns Whether the file type is valid (true or false).
+     */
     static isValidFileType(fileType: string): boolean {
         return ["Topic", "Project", "Task", "Metadata"].includes(fileType);
+    }
+
+    /**
+     * Checks if the given file is a valid PrjTaskManagement file (Topic, Project or Task).
+     * @param file The file to check.
+     * @returns Whether the file is a valid PrjTaskManagement file (true or false).
+     */
+    static isPrjTaskManagementFile(file: TFile): boolean {
+        const metadata = Global.getInstance().metadataCache.getEntry(file);
+        if (!metadata) {
+            return false;
+        }
+        const type = metadata.metadata.frontmatter?.type as FileType | undefined | null;
+        if (!type) {
+            return false;
+        }
+        return ["Topic", "Project", "Task"].includes(type);
     }
 
     /**

--- a/src/libs/MetadataCache.ts
+++ b/src/libs/MetadataCache.ts
@@ -201,6 +201,28 @@ export default class MetadataCache {
     }
 
     /**
+     * Get the metadata cache entry for a file.
+     * @param file The file to get from the metadata cache.
+     * @returns {FileMetadata | undefined} The metadata cache entry for the file.
+     * @remarks - This method returns undefined if the metadata cache is not ready.
+     * - As key the file path is used!
+     */
+    public getEntry(file: TFile): FileMetadata | undefined {
+        if (this.metadataCache) {
+            const metadata = this.metadataCache.get(file.path);
+            if (metadata) {
+                return metadata;
+            } else {
+                this.logger.warn(`No metadata cache entry found for file ${file.path}`);
+                return undefined;
+            }
+        } else {
+            this.logger.error("Metadata cache not initialized");
+            return undefined;
+        }
+    }
+
+    /**
      * Add a file to the metadata cache
      * @param file The file to add to the metadata cache
      */

--- a/src/libs/MetadataCache.ts
+++ b/src/libs/MetadataCache.ts
@@ -256,14 +256,13 @@ export default class MetadataCache {
      * Update a file in the metadata cache
      * @param file The file to update in the metadata cache
      */
-    private async updateEntry(file: TFile) {
+    private async updateEntry(file: TFile, cache: CachedMetadata) {
         if (this.metadataCache) {
             const entry = this.metadataCache.get(file.path);
-            const metadata = this.app.metadataCache.getFileCache(file);
-            if (entry && metadata) {
+            if (entry && cache) {
                 // Check if a event should be emitted
-                this.onChangedMetadata(metadata, entry.metadata, file);
-                entry.metadata = metadata;
+                this.onChangedMetadata(cache, entry.metadata, file);
+                entry.metadata = cache;
             } else if (!entry) {
                 this.logger.warn(`No metadata cache entry found for file ${file.path}`);
             } else {
@@ -316,12 +315,15 @@ export default class MetadataCache {
     /**
      * Event handler for the changed event
      * @param file Changed file object
+     * @param data Changed complete file content
+     * @param cache Cached metadata
      */
-    private changedEventHandler(file: TFile) {
+    private changedEventHandler(file: TFile, data: string, cache: CachedMetadata) {
+        this.logger.trace(`File ${file.path} changed. Data-content:`, { data }, "Cache-metadata:", cache);
         if (this.metadataCache) {
             const existingEntry = this.metadataCache.get(file.path);
             if (existingEntry) {
-                this.updateEntry(file);
+                this.updateEntry(file, cache);
             } else {
                 this.addEntry(file);
             }

--- a/src/libs/Modals/ChangeStatusModal.ts
+++ b/src/libs/Modals/ChangeStatusModal.ts
@@ -1,0 +1,83 @@
+import { Modal, Setting } from "obsidian";
+import Lng from "src/classes/Lng";
+import { Status } from "src/types/PrjTypes";
+import Helper from "../Helper";
+import StaticPrjTaskManagementModel from "../StaticModels/StaticPrjTaskManagementModel";
+import { PrjTaskManagementModel } from "src/models/PrjTaskManagementModel";
+import ProjectData from "src/types/ProjectData";
+import TaskData from "src/types/TaskData";
+import TopicData from "src/types/TopicData";
+import Global from "src/classes/Global";
+
+export default class ChangeStatusModal extends Modal {
+    newStatus: Status;
+    model: (PrjTaskManagementModel<TaskData | TopicData | ProjectData>);
+    onSubmit: (newStatus: Status, file: (PrjTaskManagementModel<TaskData | TopicData | ProjectData>)) => void;
+
+    constructor() {
+        super(Global.getInstance().app);
+    }
+
+    override open() {
+        const workspace = this.app.workspace;
+        const activeFile = workspace.getActiveFile();
+        if (!activeFile) {
+            return;
+        } else if (!Helper.isPrjTaskManagementFile(activeFile)) {
+            return;
+        }
+        const model = StaticPrjTaskManagementModel.getCorospondingModel(activeFile);
+        if (!model) {
+            return;
+        }
+        this.model = model;
+        super.open();
+    }
+
+    onOpen() {
+        const { contentEl } = this;
+        contentEl.createEl("h2", { text: Lng.gt("Change Status") });
+
+        new Setting(contentEl)
+            .setName(Lng.gt("New Status"))
+            .addDropdown((cb) => {
+                cb.addOption("Active", Lng.gt("StatusActive"));
+                cb.addOption("Waiting", Lng.gt("StatusWaiting"));
+                cb.addOption("Later", Lng.gt("StatusLater"));
+                cb.addOption("Someday", Lng.gt("StatusSomeday"));
+                cb.addOption("Done", Lng.gt("StatusDone"));
+                cb.setValue(this.model.data.status ?? "Active");
+                cb.onChange((value) => {
+                    this.newStatus = value as Status;
+                });
+            });
+
+        new Setting(contentEl)
+            .addButton((btn) =>
+                btn.setButtonText(Lng.gt("Change"))
+                    .setCta()
+                    .onClick(() => {
+                        this.close();
+                        this.model.changeStatus(this.newStatus);
+                    }));
+    }
+
+    onClose() {
+        const { contentEl } = this;
+        contentEl.empty();
+    }
+
+    /**
+     * Registers the command to open the modal
+     * @remarks No cleanup needed
+     */
+    public static registerCommand(): void {
+        const global = Global.getInstance();
+        global.logger.trace("Registering 'CreateNewMetadataModal' commands");
+        global.plugin.addCommand({
+            id: "change-prj-status",
+            name: Lng.gt("Change Status"),
+            callback: () => new ChangeStatusModal().open()
+        });
+    }
+}

--- a/src/libs/StaticModels/StaticPrjTaskManagementModel.ts
+++ b/src/libs/StaticModels/StaticPrjTaskManagementModel.ts
@@ -1,0 +1,35 @@
+import { TFile } from "obsidian";
+import Global from "src/classes/Global";
+import { PrjTaskManagementModel } from "src/models/PrjTaskManagementModel";
+import { ProjectModel } from "src/models/ProjectModel";
+import { TaskModel } from "src/models/TaskModel";
+import { TopicModel } from "src/models/TopicModel";
+import ProjectData from "src/types/ProjectData";
+import TaskData from "src/types/TaskData";
+import TopicData from "src/types/TopicData";
+
+export default class StaticPrjTaskManagementModel {
+    public static getCorospondingModel(file: TFile): (PrjTaskManagementModel<TaskData | TopicData | ProjectData>) | undefined {
+        const entry = Global.getInstance().metadataCache.getEntry(file);
+        if (!entry) {
+            return undefined;
+        }
+        const type = entry.metadata.frontmatter?.type
+        if (!type) {
+            return undefined;
+        }
+        switch (type) {
+            case "Topic":
+                return new TopicModel(entry.file) as PrjTaskManagementModel<TopicData>;
+                break;
+            case "Project":
+                return new ProjectModel(entry.file) as PrjTaskManagementModel<ProjectData>;
+                break;
+            case "Task":
+                return new TaskModel(entry.file) as PrjTaskManagementModel<TaskData>;
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import Global from './classes/Global';
 import GetMetadata from './libs/ContextMenus/GetMetadata';
 import API from './classes/API';
 import CreateNewMetadataModal from './libs/Modals/CreateNewMetadataModal';
+import ChangeStatusModal from './libs/Modals/ChangeStatusModal';
 
 export default class Prj extends Plugin {
 	public settings: PrjSettings;
@@ -40,6 +41,9 @@ export default class Prj extends Plugin {
 
 		// Create New Metadata File Command
 		CreateNewMetadataModal.registerCommand();
+
+		// Change Status Command
+		ChangeStatusModal.registerCommand();
 
 		// API
 		this.api = new API();

--- a/src/models/BaseModel.ts
+++ b/src/models/BaseModel.ts
@@ -8,6 +8,7 @@ import Logging from "src/classes/Logging";
 export class BaseModel<T extends object> extends TransactionModel<T> {
     protected global = Global.getInstance();
     protected app = Global.getInstance().app;
+    protected metadataCache = Global.getInstance().metadataCache;
     protected logger: Logging = Global.getInstance().logger;
 
     private _file: TFile | undefined;
@@ -250,10 +251,10 @@ export class BaseModel<T extends object> extends TransactionModel<T> {
      */
     private getMetadata(): Record<string, unknown> | null {
         if (!this._file) return null;
-        const cachedMetadata = this.app?.metadataCache?.getCache(this._file.path);
+        const cachedMetadata = this.metadataCache.getEntry(this._file);
 
-        if (cachedMetadata && cachedMetadata.frontmatter) {
-            return cachedMetadata.frontmatter as Record<string, unknown>;
+        if (cachedMetadata && cachedMetadata.metadata && cachedMetadata.metadata.frontmatter) {
+            return cachedMetadata.metadata.frontmatter as Record<string, unknown>;
         } else {
             this.logger.error(`No Metadata found for ${this._file.path}`);
             return null;

--- a/src/models/BaseModel.ts
+++ b/src/models/BaseModel.ts
@@ -1,4 +1,5 @@
-import { TFile } from "obsidian";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { TFile, FileManager } from "obsidian";
 import Global from "../classes/Global";
 import { TransactionModel } from "./TransactionModel";
 import { YamlKeyMap } from "../types/YamlKeyMap";
@@ -8,6 +9,7 @@ export class BaseModel<T extends object> extends TransactionModel<T> {
     protected global = Global.getInstance();
     protected app = Global.getInstance().app;
     protected logger: Logging = Global.getInstance().logger;
+
     private _file: TFile | undefined;
     public get file(): TFile {
         if (this._file === undefined) {
@@ -15,6 +17,13 @@ export class BaseModel<T extends object> extends TransactionModel<T> {
         }
         return this._file as TFile;
     }
+    /**
+     * Sets the file of the model if not already set.
+     * @param value The file to set.
+     * @remarks - If the file is already set, a warning is logged and the file is not set.
+     * - If the given file is set, the `writeChanges` function is set. 
+     * And the default transaction is finished. Changes between the file and the data object are written.
+     */
     public set file(value: TFile) {
         if (this._file === undefined) {
             super.setWriteChanges((update) => {
@@ -26,13 +35,29 @@ export class BaseModel<T extends object> extends TransactionModel<T> {
             this.logger.warn("File already set");
         }
     }
+    /**
+     * The constructor of the data object.
+     * @remarks - This is needed to create a new instance of the data object.
+     * - It is set in the constructor of this class.
+     * @see {@link BaseModel.constructor}
+     */
     private ctor: new (data?: Partial<T>) => T;
+    /**
+     * The proxy of the data object.
+     * @see {@link BaseModel._data}
+     * @see {@link BaseModel.createProxy}
+     */
     private dataProxy: T;
     /**
      * The proxy map to use.
      * @see {@link BaseModel.createProxy}
      */
     private proxyMap: WeakMap<object, unknown> = new WeakMap();
+    /**
+     * The yaml key map to use.
+     * @see {@link YamlKeyMap}
+     * @see {@link BaseModel.initYamlKeyMap}
+     */
     private yamlKeyMap: YamlKeyMap | undefined;
 
     /**
@@ -89,6 +114,11 @@ export class BaseModel<T extends object> extends TransactionModel<T> {
         return this.dataProxy;
     }
 
+    /**
+     * Sets the data object.
+     * @param values The values to set.
+     * @remarks Overwrites only the given values.
+     */
     protected set _data(values: Partial<T>) {
         const dataObject: T = new this.ctor(values);
         for (const key in dataObject) {
@@ -96,16 +126,33 @@ export class BaseModel<T extends object> extends TransactionModel<T> {
         }
     }
 
+    /**
+     * Returns the frontmatter of the file if available.
+     * @see {@link BaseModel.getMetadata}
+     */
     private get frontmatter(): Record<string, unknown> {
         return this.getMetadata() ?? {};
     }
 
+    /**
+     * Sets the frontmatter of the file.
+     * @param value The new frontmatter to set.
+     * @remarks - Overwrites only the given values.
+     * - If the file is not set, the frontmatter is not set.
+     * @see {@link BaseModel.setFrontmatter}
+     */
     private set frontmatter(value: Record<string, unknown>) {
         (async () => {
             await this.setFrontmatter(value);
         })();
     }
 
+    /**
+     * Updates the key value pair in the frontmatter.
+     * @param value The new value to set.
+     * @remarks - Overwrites only the given values.
+     * - If the file is not set, the frontmatter is not set.
+     */
     private async setFrontmatter(value: Record<string, unknown>) {
         if (!this._file) return Promise.resolve();
         try {
@@ -123,6 +170,14 @@ export class BaseModel<T extends object> extends TransactionModel<T> {
      * @param obj The object to create a proxy for.
      * @param path The path of the object. e.g. `data.title`
      * @returns The proxy object.
+     * @remarks - If the object is already proxied, the existing proxy is returned.
+     * - If the object is not proxied, a new proxy is created
+     * and the `proxyMap` is updated. The proxy is returned.
+     * @see {@link BaseModel.proxyMap}
+     * - If the object is an object, the function is called recursively.
+     * - Only non-proxy values are sent to the `updateKeyValue` function.
+     * @see {@link BaseModel.resolveProxyValue}
+     * @see {@link BaseModel.updateKeyValue}
      */
     private createProxy(obj: Partial<T>, path = ""): unknown {
         const existingProxy = this.proxyMap.get(obj);
@@ -169,6 +224,12 @@ export class BaseModel<T extends object> extends TransactionModel<T> {
         // Return only non-proxy values
         return value;
     }
+
+    /**
+     * Returns the value of the given property key.
+     * @param property The property key to get the value for.
+     * @returns The value of the given property key.
+     */
     private getPropertyKey(property: string | symbol): string {
         return typeof property === 'symbol' ? property.toString() : property;
     }
@@ -183,10 +244,10 @@ export class BaseModel<T extends object> extends TransactionModel<T> {
         }
     }
 
-    private getPropertyKey(property: string | symbol): string {
-        return typeof property === 'symbol' ? property.toString() : property;
-    }
-
+    /**
+     * Gets the metadata of the file if a file is set.
+     * @returns The metadata of the file or `null` if no fileor metadata is found.
+     */
     private getMetadata(): Record<string, unknown> | null {
         if (!this._file) return null;
         const cachedMetadata = this.app?.metadataCache?.getCache(this._file.path);
@@ -199,6 +260,14 @@ export class BaseModel<T extends object> extends TransactionModel<T> {
         }
     }
 
+    /**
+     * Recursively updates the frontmatter object with the given updates.
+     * @param frontmatter The frontmatter object to update. Normally transferred from the `processFrontMatter` function.
+     * @see {@link FileManager.processFrontMatter}
+     * @param updates A partial object containing the updates.
+     * @remarks - `null` clears the value of the key.
+     * - `undefined` leaves the value of the key unchanged.
+     */
     private updateNestedFrontmatterObjects(frontmatter: Record<string, unknown>, updates: object) {
         Object.entries(updates).forEach(([key, value]) => {
             if (this.yamlKeyMap && this.yamlKeyMap[key]) {

--- a/src/models/TransactionModel.ts
+++ b/src/models/TransactionModel.ts
@@ -37,6 +37,12 @@ export class TransactionModel<T> {
 
     public setWriteChanges(writeChanges: (update: T) => Promise<void>) {
         this.writeChanges = writeChanges;
+        if (this.isTransactionActive && !(Object.keys(this.changes).length === 0 && this.changes.constructor === Object)) {
+            this.callWriteChanges();
+            this.changes = {};
+            this.transactionActive = false;
+        }
+        this.transactionActive = false;
     }
 
     protected callWriteChanges(update: T = this.changes as T) {

--- a/src/models/TransactionModel.ts
+++ b/src/models/TransactionModel.ts
@@ -14,7 +14,7 @@ import Logging from "src/classes/Logging";
  */
 export class TransactionModel<T> {
     protected logger: Logging = Global.getInstance().logger;
-    protected transactionActive = false;
+    private transactionActive = false;
     protected changes: Partial<T> = {};
     /**
      * A function that writes the changes to the file.
@@ -136,7 +136,7 @@ export class TransactionModel<T> {
      * Returns whether a transaction is active.
      * @returns `true` if a transaction is active, otherwise `false`.
      */
-    private get isTransactionActive(): boolean {
+    public get isTransactionActive(): boolean {
         return this.transactionActive;
     }
 }

--- a/src/translations.json
+++ b/src/translations.json
@@ -2,6 +2,8 @@
     {
         "lang": "en",
         "translations": {
+            "Change": "Change",
+            "Change Status": "Change status..",
             "Cluster": "Document Cluster",
             "Content": "Content",
             "Date": "Date",
@@ -61,6 +63,8 @@
     {
         "lang": "de",
         "translations": {
+            "Change": "Ändern",
+            "Change Status": "Status ändern..",
             "Cluster": "Dokumenten Cluster",
             "Content": "Inhalt",
             "Date": "Datum",

--- a/src/types/PrjTypes.ts
+++ b/src/types/PrjTypes.ts
@@ -4,6 +4,7 @@ import Helper from "src/libs/Helper";
 /**
  * File types used in the app
  * @see {@link Helper.isValidFileType} for a function to check if a string is a valid file type. Change this function if you add a new file type.
+ * @see {@link Helper.isPrjTaskManagementFile} for a function to check if a file is a prj task management file. Change this function if you add a new file type.
  */
 export type FileType = "Topic" | "Project" | "Task" | "Metadata";
 


### PR DESCRIPTION
* # Extended proxy handling in `BaseModel`
- A `WeakMap` is now used to check whether a corresponding proxy already exists. If it exists, the existing one is returned, otherwise a new one is created. The aim is to improve performance and prevent recursion.
- It is now ensured that no proxies are passed to the `updateKeyValue` method, but only the basic objects/values. A new method `resolveProxyValue` has been added for this purpose. The only aim here is to prevent recursion, which could previously occur in some cases.

* # Refactoring
- Added comments to the `BaseModel` class.
- Comments added or clarified here and there.

* # Translations
- Translations added.

* # `TransactionModel`
- Added a check to the `setWriteChanges` method whether changes were saved between the initialization without passing the `writeChanges` function and the setting of these changes. If yes, these are now saved similar to a manually ended transaction.

* # `MetadataCache`
- Added a `getEntry` method.
- Since the internal cache uses the path as the key, it can be searched effectively using the path instead of running through all entries.
- This method now simply makes this efficient procedure available to public.

* # `Helper`
- Added an `isPrjTaskManagementFile` method.
- Similar to the `isValidFileType` method, this checks whether the file is a file belonging to the task management.

* # `StaticPrjTaskManagementModel`
- Similar to the document model, a static class for auxiliary functions in connection with task management has been added.

* # `BaseModel`
- Switched to the use of its own metadata cache.

* # `PrjTaskManagementModel`
- Added the method `changeStatus` to change the current status and add a corresponding history entry.
- Added the method `addHistoryEntry` to add a new history entry.

* # `MetadataCache`
- Optimized the change detection.

* # `ChangeStatusModal`
- Form for changing the status of a project file added.
- Based on Obsidian's own modal system.
- Has a state method to register the corresponding command.

# `Main`
- The corresponding command is registered.

# `TransactionModel`
- Made the `transactionActive` field private and made the `isTransactionActive` getter public.