### PR TITLE
Features/add-create-new-project-modal

### DIFF
--- a/src/classes/API.ts
+++ b/src/classes/API.ts
@@ -1,9 +1,11 @@
 import Global from "src/classes/Global";
+import Helper from "src/libs/Helper";
 import { StaticDocumentModel } from "src/libs/StaticModels/StaticDocumentModel";
 
 export default class API {
     public global: Global
     public documentModel = StaticDocumentModel;
+    public helper = Helper;
 
     constructor() {
         this.global = Global.getInstance();

--- a/src/classes/SettingsTab.ts
+++ b/src/classes/SettingsTab.ts
@@ -53,12 +53,15 @@ export class SettingTab extends PluginSettingTab {
             .setHeading()
             .setName('Localisation');
 
-        // Language
+        // Language (Dropdown)
         new Setting(containerEl)
             .setName('Language')
             .setDesc('The language to use')
-            .addText(text => text
-                .setPlaceholder('en | de')
+            .addDropdown(dropdown => dropdown
+                .addOptions({
+                    'en': 'English',
+                    'de': 'Deutsch'
+                })
                 .setValue(this.plugin.settings.language)
                 .onChange(async (value) => {
                     this.plugin.settings.language = value;
@@ -94,7 +97,7 @@ export class SettingTab extends PluginSettingTab {
             .setName('Base Tag')
             .setDesc('The Base Tag for all Elements')
             .addText(text => text
-                .setPlaceholder('#YourBaseTag')
+                .setPlaceholder('YourBaseTag (without / and #)')
                 .setValue(this.plugin.settings.baseTag)
                 .onChange(async (value) => {
                     this.plugin.settings.baseTag = value;
@@ -252,6 +255,143 @@ export class SettingTab extends PluginSettingTab {
                 .setValue(this.plugin.settings.documentSettings.clusterSymbol)
                 .onChange(async (value) => {
                     this.plugin.settings.documentSettings.clusterSymbol = value;
+                    await this.plugin.saveSettings();
+                }));
+
+        // Default Folder
+        new Setting(containerEl)
+            .setName('Default Folder')
+            .setDesc('The default folder for new Documents')
+            .addText(text => text
+                .setPlaceholder('')
+                .setValue(this.plugin.settings.documentSettings.defaultFolder)
+                .onChange(async (value) => {
+                    this.plugin.settings.documentSettings.defaultFolder = value;
+                    await this.plugin.saveSettings();
+                }));
+
+        // Template file
+        new Setting(containerEl)
+            .setName('Template File')
+            .setDesc('The Template file for new Documents')
+            .addText(text => text
+                .setPlaceholder('')
+                .setValue(this.plugin.settings.documentSettings.template)
+                .onChange(async (value) => {
+                    this.plugin.settings.documentSettings.template = value;
+                    await this.plugin.saveSettings();
+                }));
+
+        // Project Settings
+        new Setting(containerEl)
+            .setHeading()
+            .setName('Project Settings');
+
+        // Topic Symbol
+        new Setting(containerEl)
+            .setName('Topic Symbol')
+            .setDesc('The Symbol for Topics')
+            .addText(text => text
+                .setPlaceholder('album')
+                .setValue(this.plugin.settings.prjSettings.topicSymbol)
+                .onChange(async (value) => {
+                    this.plugin.settings.prjSettings.topicSymbol = value;
+                    await this.plugin.saveSettings();
+                }));
+
+        // Topic Folder
+        new Setting(containerEl)
+            .setName('Topic Folder')
+            .setDesc('The default folder for new Topics')
+            .addText(text => text
+                .setPlaceholder('')
+                .setValue(this.plugin.settings.prjSettings.topicFolder)
+                .onChange(async (value) => {
+                    this.plugin.settings.prjSettings.topicFolder = value;
+                    await this.plugin.saveSettings();
+                }));
+
+        // Template file
+        new Setting(containerEl)
+            .setName('Template File')
+            .setDesc('The Template file for new Topics')
+            .addText(text => text
+                .setPlaceholder('')
+                .setValue(this.plugin.settings.prjSettings.topicTemplate)
+                .onChange(async (value) => {
+                    this.plugin.settings.prjSettings.topicTemplate = value;
+                    await this.plugin.saveSettings();
+                }));
+
+        // Project Symbol
+        new Setting(containerEl)
+            .setName('Project Symbol')
+            .setDesc('The Symbol for Projects')
+            .addText(text => text
+                .setPlaceholder('album')
+                .setValue(this.plugin.settings.prjSettings.projectSymbol)
+                .onChange(async (value) => {
+                    this.plugin.settings.prjSettings.projectSymbol = value;
+                    await this.plugin.saveSettings();
+                }));
+
+        // Project Folder
+        new Setting(containerEl)
+            .setName('Project Folder')
+            .setDesc('The default folder for new Projects')
+            .addText(text => text
+                .setPlaceholder('')
+                .setValue(this.plugin.settings.prjSettings.projectFolder)
+                .onChange(async (value) => {
+                    this.plugin.settings.prjSettings.projectFolder = value;
+                    await this.plugin.saveSettings();
+                }));
+
+        // Template file
+        new Setting(containerEl)
+            .setName('Template File')
+            .setDesc('The Template file for new Projects')
+            .addText(text => text
+                .setPlaceholder('')
+                .setValue(this.plugin.settings.prjSettings.projectTemplate)
+                .onChange(async (value) => {
+                    this.plugin.settings.prjSettings.projectTemplate = value;
+                    await this.plugin.saveSettings();
+                }));
+
+        // Task Symbol
+        new Setting(containerEl)
+            .setName('Task Symbol')
+            .setDesc('The Symbol for Tasks')
+            .addText(text => text
+                .setPlaceholder('album')
+                .setValue(this.plugin.settings.prjSettings.taskSymbol)
+                .onChange(async (value) => {
+                    this.plugin.settings.prjSettings.taskSymbol = value;
+                    await this.plugin.saveSettings();
+                }));
+
+        // Task Folder
+        new Setting(containerEl)
+            .setName('Task Folder')
+            .setDesc('The default folder for new Tasks')
+            .addText(text => text
+                .setPlaceholder('')
+                .setValue(this.plugin.settings.prjSettings.taskFolder)
+                .onChange(async (value) => {
+                    this.plugin.settings.prjSettings.taskFolder = value;
+                    await this.plugin.saveSettings();
+                }));
+
+        // Template file
+        new Setting(containerEl)
+            .setName('Template File')
+            .setDesc('The Template file for new Tasks')
+            .addText(text => text
+                .setPlaceholder('')
+                .setValue(this.plugin.settings.prjSettings.taskTemplate)
+                .onChange(async (value) => {
+                    this.plugin.settings.prjSettings.taskTemplate = value;
                     await this.plugin.saveSettings();
                 }));
     }

--- a/src/interfaces/IPrjTaskManagement.ts
+++ b/src/interfaces/IPrjTaskManagement.ts
@@ -10,4 +10,5 @@ export default interface IPrjTaskManagement {
     energy: Energy | null | undefined;
     due: string | null | undefined;
     history: HistoryEntries | null | undefined;
+    aliases: string[] | null | undefined;
 }

--- a/src/libs/BlockRenderComponents/DocumentBlockRenderComponent.ts
+++ b/src/libs/BlockRenderComponents/DocumentBlockRenderComponent.ts
@@ -26,6 +26,7 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
         filter: ["Documents"],
         maxDocuments: this.global.settings.defaultMaxShow,
         search: undefined,
+        searchText: undefined,
         batchSize: 8,
         sleepBetweenBatches: 10
     };
@@ -136,7 +137,8 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
 
         const searchBox = SearchInput.create(
             this.component,
-            this.onSearch.bind(this));
+            this.onSearch.bind(this),
+            this.settings.searchText);
         headerFilterButtons.appendChild(searchBox);
     }
 
@@ -179,13 +181,16 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
     private async onSearch(search: string, key: string): Promise<string> {
         if (key === "Enter") {
             if (search !== "") {
+                this.settings.searchText = search;
                 this.settings.search = Search.parseSearchText(search);
                 this.onFilter();
             } else {
+                this.settings.searchText = undefined;
                 this.settings.search = undefined;
                 this.onFilter();
             }
         } else if (key === "Escape") {
+            this.settings.searchText = undefined;
             this.settings.search = undefined;
             this.onFilter();
             return "";
@@ -488,7 +493,7 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
      */
     protected async getModels(): Promise<DocumentModel[]> {
         const templateFolder = this.global.settings.templateFolder;
-        const allDocumentFiles = this.metadataCache.filter(file => {
+        const allDocumentFiles = this.metadataCache.cache.filter(file => {
             const defaultFilter = file.metadata.frontmatter?.type === "Metadata" &&
                 file.file.path !== this.processorSettings.source &&
                 !file.file.path.startsWith(templateFolder);
@@ -579,6 +584,11 @@ type DocumentBlockRenderSettings = {
      * If undefined, no search filter is applied.
      */
     search: SearchTermsArray | undefined,
+
+    /**
+     * The search text.
+     */
+    searchText: string | undefined,
 
     /**
      * The number of documents to process in one batch.

--- a/src/libs/BlockRenderComponents/InnerComponents/ProjectComponents.ts
+++ b/src/libs/BlockRenderComponents/InnerComponents/ProjectComponents.ts
@@ -63,7 +63,7 @@ export default class ProjectComponents {
         description: string,
         onWrite: (value: string) => void) {
         new EditableDataView(container, component)
-            .addText(text => text
+            .addTextarea(text => text
                 .setValue(description)
                 .setTitle(Lng.gt("Description"))
                 .setPlaceholder(Lng.gt("Description"))

--- a/src/libs/BlockRenderComponents/InnerComponents/SearchInput.ts
+++ b/src/libs/BlockRenderComponents/InnerComponents/SearchInput.ts
@@ -24,7 +24,7 @@ export default class SearchInput {
      *  - `search-box-sizer` - The sizer of the search input component.
      *  - `search-box` - The search box of the search input component.
      */
-    public static create(component: Component, onSearch: SearchCallback): DocumentFragment {
+    public static create(component: Component, onSearch: SearchCallback, defaultText?: string): DocumentFragment {
         const logger = Global.getInstance().logger;
         const headerItemContainer = document.createDocumentFragment();
 
@@ -35,6 +35,11 @@ export default class SearchInput {
         SearchInput.createSearchLabel(searchLabelContainer);
         const searchBoxSizer = SearchInput.createSearchBoxSizer(searchLabelContainer);
         const searchBoxInput = SearchInput.createSearchBoxInput(searchBoxSizer);
+
+        if (defaultText) {
+            this.setSearchBoxSizerValue(searchBoxSizer, defaultText);
+            this.setSearchBoxInputValue(searchBoxInput, defaultText);
+        }
 
         /**
          * Register input event to set the search box sizer value.

--- a/src/libs/BlockRenderComponents/TableBlockRenderComponent.ts
+++ b/src/libs/BlockRenderComponents/TableBlockRenderComponent.ts
@@ -11,7 +11,7 @@ export default abstract class TableBlockRenderComponent<T extends IPrjModel<unkn
     //#region General properties
     protected global = Global.getInstance();
     protected logger = this.global.logger;
-    protected metadataCache = this.global.metadataCache.cache;
+    protected metadataCache = this.global.metadataCache;
     protected fileCache = this.global.fileCache;
     //#endregion
     //#region Component properties

--- a/src/libs/BlockRenderComponents/TableBlockRenderComponent.ts
+++ b/src/libs/BlockRenderComponents/TableBlockRenderComponent.ts
@@ -11,7 +11,7 @@ export default abstract class TableBlockRenderComponent<T extends IPrjModel<unkn
     //#region General properties
     protected global = Global.getInstance();
     protected logger = this.global.logger;
-    protected metadataCache = this.global.metadataCache.Cache;
+    protected metadataCache = this.global.metadataCache.cache;
     protected fileCache = this.global.fileCache;
     //#endregion
     //#region Component properties

--- a/src/libs/ContextMenus/GetMetadata.ts
+++ b/src/libs/ContextMenus/GetMetadata.ts
@@ -10,7 +10,7 @@ export default class GetMetadata {
     private app = Global.getInstance().app;
     private logger = Global.getInstance().logger;
     private plugin = Global.getInstance().plugin;
-    private metadataCache = Global.getInstance().metadataCache.Cache;
+    private metadataCache = Global.getInstance().metadataCache.cache;
     protected eventsRegistered = false;
     protected bindContextMenu = this.onContextMenu.bind(this);
 

--- a/src/libs/ContextMenus/GetMetadata.ts
+++ b/src/libs/ContextMenus/GetMetadata.ts
@@ -4,6 +4,7 @@ import Lng from "src/classes/Lng";
 import { DocumentModel } from "src/models/DocumentModel";
 import { FileType } from "src/types/PrjTypes";
 import { FileMetadata } from "../MetadataCache";
+import Helper from "../Helper";
 
 export default class GetMetadata {
     static instance: GetMetadata;
@@ -86,7 +87,7 @@ export default class GetMetadata {
                 item.setTitle(Lng.gt("ShowMetadataFile"))
                     .setIcon(document.getCorospondingSymbol())
                     .onClick(async () => {
-                        await this.openMetadataFile(document.file);
+                        await Helper.openFile(document.file);
                     }
                     );
             });
@@ -124,16 +125,6 @@ export default class GetMetadata {
             return;
         }
         const document = new DocumentModel(metadataFile.file);
-        await this.openMetadataFile(document.file);
-    }
-
-    private async openMetadataFile(file: TFile) {
-        this.logger.trace(`Opening metadata file for ${file.name}`);
-        const workspace = this.app.workspace;
-        const newLeaf = workspace.getLeaf(true);
-        await newLeaf.openFile(file);
-        const view = newLeaf.getViewState();
-        view.state.mode = 'preview';
-        newLeaf.setViewState(view);
+        await Helper.openFile(document.file);
     }
 }

--- a/src/libs/Helper.ts
+++ b/src/libs/Helper.ts
@@ -239,6 +239,16 @@ export default class Helper {
         });
         return tagFound !== undefined;
     }
+
+    static async openFile(file: TFile): Promise<void> {
+        Global.getInstance().logger.trace(`Opening metadata file for ${file.name}`);
+        const workspace = Global.getInstance().app.workspace;
+        const newLeaf = workspace.getLeaf(true);
+        await newLeaf.openFile(file);
+        const view = newLeaf.getViewState();
+        view.state.mode = 'preview';
+        newLeaf.setViewState(view);
+    }
 }
 
 export type WikilinkData = {

--- a/src/libs/Helper.ts
+++ b/src/libs/Helper.ts
@@ -163,6 +163,82 @@ export default class Helper {
         const emojiRegex = /(\p{Emoji_Presentation}|\p{Emoji}\uFE0F)/u;
         return emojiRegex.test(str);
     }
+
+    /**
+     * Generates an acronym from the given text.
+     * @param text The input text to generate the acronym from.
+     * @param length The desired length of the acronym, default is 6.
+     * @param prefix The prefix for the acronym, default is current year.
+     * @returns The generated acronym with the specified prefix.
+     */
+    static generateAcronym(text: string, length = 6, prefix = 'year'): string {
+        // Return an empty string if text is not provided
+        if (!text) {
+            return '';
+        }
+
+        // Determine the prefix based on the input or date
+        let prefixValue = '';
+        if (prefix === 'year') {
+            // Extract the last two digits of the current year
+            const currentYear: number = new Date().getFullYear();
+            prefixValue = currentYear.toString().substring(2);
+        } else if (prefix === 'month') {
+            // Format the current month as a two-digit number
+            const currentMonth: number = new Date().getMonth() + 1;
+            prefixValue = currentMonth.toString().padStart(2, '0');
+        } else if (prefix) {
+            // Use the provided prefix if it's not related to date
+            prefixValue = prefix;
+        }
+
+        // Split the text into words and filter out empty words
+        const words: string[] = text.split(' ').filter(word => word.trim().length > 0);
+        let acronym = '';
+        // Determine the maximum number of characters per word
+        let maxChars: number = Math.floor(length / words.length);
+        // Ensure at least one character per word
+        if (maxChars < 1) maxChars = 1;
+        // Adjust maxChars if total length is insufficient
+        if (maxChars * words.length < length) maxChars++;
+
+        // Construct the acronym from the words
+        for (let i = 0; i < words.length; i++) {
+            acronym += words[i].substring(0, Math.min(maxChars, words[i].length));
+            // Stop if desired length is reached
+            if (acronym.length >= length) break;
+        }
+
+        // Limit the acronym to the desired length
+        acronym = acronym.substring(0, length);
+        // Combine the prefix and the acronym
+        return prefixValue + acronym;
+    }
+
+    static getActiveFile(): TFile | undefined {
+        const workspace = Global.getInstance().app.workspace;
+        const activeFile = workspace.getActiveFile();
+        if (!activeFile) {
+            return undefined;
+        }
+        return activeFile;
+    }
+
+    static existTag(tag: string): boolean {
+        const metadataCache = Global.getInstance().metadataCache.cache;
+        const tagFound = metadataCache.find((value) => {
+            const tags = value.metadata?.frontmatter?.tags;
+            if (!tags) {
+                return false;
+            }
+            if (Array.isArray(tags)) {
+                return tags.includes(tag);
+            } else {
+                return tags === tag;
+            }
+        });
+        return tagFound !== undefined;
+    }
 }
 
 export type WikilinkData = {

--- a/src/libs/MarkdownBlockProcessor.ts
+++ b/src/libs/MarkdownBlockProcessor.ts
@@ -28,7 +28,7 @@ export default class MarkdownBlockProcessor {
 
         const global = Global.getInstance();
         await global.metadataCache.waitForCacheReady();
-        const cache = global.metadataCache.Cache;
+        const cache = global.metadataCache.cache;
         const logger = global.logger;
 
         const cmp = new MarkdownRenderChild(el);

--- a/src/libs/MetadataCache.ts
+++ b/src/libs/MetadataCache.ts
@@ -31,7 +31,7 @@ export default class MetadataCache {
      * @returns {FileMetadata[]} Array of FileMetadata objects
      * @description This method returns the metadata cache as an array of FileMetadata objects. The FileMetadata object contains the file and the cached metadata.
      */
-    public get Cache(): FileMetadata[] {
+    public get cache(): FileMetadata[] {
         if (this.metadataCacheReady && this.metadataCache) {
             return Array.from(this.metadataCache.values());
         } else {

--- a/src/libs/Modals/BaseModalForm.ts
+++ b/src/libs/Modals/BaseModalForm.ts
@@ -2,9 +2,10 @@ import { App } from "obsidian";
 import Global from "src/classes/Global";
 import { FormConfiguration, IFormResult, IModalForm } from "src/types/ModalFormType";
 
-export default abstract class ModalFormBase {
+export default abstract class BaseModalForm {
     protected app: App = Global.getInstance().app;
     protected settings = Global.getInstance().settings;
+    protected global = Global.getInstance();
     protected logger = Global.getInstance().logger;
     protected modalFormApi: IModalForm | null | undefined = null;
 

--- a/src/libs/Modals/CreateNewMetadataModal.ts
+++ b/src/libs/Modals/CreateNewMetadataModal.ts
@@ -6,6 +6,7 @@ import { DocumentModel } from "src/models/DocumentModel";
 import DocumentData from "src/types/DocumentData";
 import { Field, FormConfiguration, IFormResult, IResultData } from "src/types/ModalFormType";
 import BaseModalForm from "./BaseModalForm";
+import Helper from "../Helper";
 
 /**
  * Modal to create a new metadata file
@@ -33,7 +34,9 @@ export default class CreateNewMetadataModal extends BaseModalForm {
                 const modal = new CreateNewMetadataModal();
                 const result = await modal.openForm();
                 if (result) {
-                    await modal.evaluateForm(result);
+                    const document = await modal.evaluateForm(result);
+                    if (document)
+                        await Helper.openFile(document.file);
                 }
             },
         })

--- a/src/libs/Modals/CreateNewMetadataModal.ts
+++ b/src/libs/Modals/CreateNewMetadataModal.ts
@@ -5,12 +5,12 @@ import Lng from "src/classes/Lng";
 import { DocumentModel } from "src/models/DocumentModel";
 import DocumentData from "src/types/DocumentData";
 import { Field, FormConfiguration, IFormResult, IResultData } from "src/types/ModalFormType";
-import ModalFormBase from "./ModalFormBase";
+import BaseModalForm from "./BaseModalForm";
 
 /**
  * Modal to create a new metadata file
  */
-export default class CreateNewMetadataModal extends ModalFormBase {
+export default class CreateNewMetadataModal extends BaseModalForm {
 
     /**
      * Creates an instance of CreateNewMetadataModal.

--- a/src/libs/Modals/CreateNewProjectModal.ts
+++ b/src/libs/Modals/CreateNewProjectModal.ts
@@ -1,0 +1,261 @@
+import { IFormResult, FormConfiguration, Field } from "src/types/ModalFormType";
+import BaseModalForm from "./BaseModalForm";
+import Lng from "src/classes/Lng";
+import Helper from "../Helper";
+import Global from "src/classes/Global";
+import { ProjectModel } from "src/models/ProjectModel";
+import { Priority, Status } from "src/types/PrjTypes";
+import { TFile } from "obsidian";
+import path from "path";
+
+export default class CreateNewProjectModal extends BaseModalForm {
+    constructor() {
+        super();
+    }
+
+    public async openForm(): Promise<IFormResult | undefined> {
+        if (!this.isApiAvailable()) return;
+        this.logger.trace("Opening 'CreateNewProjectModal' form");
+        const activeFile = Helper.getActiveFile();
+        const tags: string[] = [];
+        if (activeFile) {
+            const cache = this.global.metadataCache.getEntry(activeFile);
+            if (cache && cache.metadata && cache.metadata.frontmatter && cache.metadata.frontmatter.tags) {
+                if (Array.isArray(cache.metadata.frontmatter.tags)) {
+                    tags.push(...cache.metadata.frontmatter.tags);
+                } else {
+                    tags.push(cache.metadata.frontmatter.tags);
+                }
+            }
+        }
+        const form = this.constructForm();
+        const result = await this.getApi().openForm(form, { values: { tags: tags } });
+        this.logger.trace(`From closes with status '${result.status}' and data:`, result.data);
+        return result;
+    }
+
+    public async evaluateForm(result: IFormResult): Promise<unknown> {
+        if (result.status !== "ok" || !result.data) return;
+
+        if (!result.data.title || typeof result.data.title !== "string") {
+            this.logger.error("No title provided");
+            return;
+        }
+        if (!result.data.tags || !Array.isArray(result.data.tags)) {
+            this.logger.error("No tags provided");
+            return;
+        }
+
+        const acronym = Helper.generateAcronym(result.data.title);
+        const mainTag = {
+            tag: "",
+            postfix: 0,
+            get fullTag() {
+                return this.tag + (this.postfix ? this.postfix : "");
+            }
+        };
+        const baseTag = this.settings.baseTag;
+        result.data.tags = result.data.tags.map((tag, index) => {
+            if (index === 0) {
+                if (tag.startsWith(baseTag)) {
+                    mainTag.tag = `${tag}/${acronym}`
+                } else {
+                    mainTag.tag = `${baseTag}/${tag}/${acronym}`;
+                }
+                while (Helper.existTag(mainTag.fullTag)) {
+                    if (!mainTag.postfix) { mainTag.postfix = 0; }
+                    this.logger.warn(`Tag '${mainTag.fullTag}' already exists`);
+                }
+                return mainTag.fullTag;
+            }
+            return tag;
+        });
+
+        if (!mainTag.tag) {
+            this.logger.error("No main tag provided");
+            return;
+        }
+
+        const project = new ProjectModel(undefined);
+
+        // Title
+        project.data.title = result.data.title;
+
+        // Description
+        if (result.data.description && typeof result.data.description === "string") {
+            project.data.description = result.data.description;
+        }
+
+        // Status
+        if (result.data.status && typeof result.data.status === "string") {
+            project.changeStatus(result.data.status as Status);
+        }
+
+        // Priority
+        if (result.data.priority && typeof result.data.priority === "number") {
+            project.data.priority = result.data.priority as Priority;
+        }
+
+        // Due Date
+        if (result.data.dueDate && typeof result.data.dueDate === "string") {
+            project.data.due = result.data.dueDate;
+        }
+
+        // Tags & Aliases
+        project.data.tags = result.data.tags;
+        project.data.aliases = [`#${mainTag.fullTag}`];
+
+        const projectFile = {
+            filepath: `${this.settings.prjSettings.projectFolder}`,
+            filename: `${acronym} - ${result.data.title}`,
+            postfix: null as number | null,
+            extension: `.md`,
+            file: null as TFile | null,
+            get fullPath() {
+                return path.join(this.filepath, this.filename + (this.postfix ? this.postfix : "") + this.extension);
+            }
+        };
+
+        projectFile.file = this.app.vault.getAbstractFileByPath(projectFile.fullPath) as TFile;
+        if (projectFile.file) { projectFile.postfix = 0; }
+        while (projectFile.file) {
+            console.warn(`Datei mit dem Namen ${projectFile.filename} existiert bereits.`);
+            if (projectFile.postfix !== null) {
+                projectFile.postfix++;
+            }
+            projectFile.file = this.app.vault.getAbstractFileByPath(projectFile.fullPath) as TFile;
+        }
+
+        const file = await this.app.vault.create(projectFile.fullPath, ``);
+        project.file = file;
+
+        return project;
+    }
+
+    protected constructForm(): FormConfiguration {
+        const form: FormConfiguration = {
+            title: `${Lng.gt("New")} ${Lng.gt("Project")}`,
+            name: "new proejct file",
+            customClassname: "",
+            fields: []
+        };
+
+        // Title
+        const title: Field = {
+            name: "title",
+            label: Lng.gt("Titel"),
+            description: Lng.gt("TitelDescription"),
+            isRequired: true,
+            input: {
+                type: "text"
+            }
+        };
+        form.fields.push(title);
+
+        // Description
+        const description: Field = {
+            name: "description",
+            label: Lng.gt("Description"),
+            description: Lng.gt("DescriptionDescription"),
+            isRequired: false,
+            input: {
+                type: "textarea"
+            }
+        };
+        form.fields.push(description);
+
+        // Status
+        const status: Field = {
+            name: "status",
+            label: Lng.gt("Status"),
+            description: Lng.gt("StatusDescription"),
+            isRequired: true,
+            input: {
+                type: "select",
+                "source": "fixed",
+                options: [
+                    { label: Lng.gt("StatusActive"), value: "Active" },
+                    { label: Lng.gt("StatusWaiting"), value: "Waiting" },
+                    { label: Lng.gt("StatusLater"), value: "Later" },
+                    { label: Lng.gt("StatusSomeday"), value: "Someday" },
+                    { label: Lng.gt("StatusDone"), value: "Done" }
+                ]
+            }
+        };
+        form.fields.push(status);
+
+        // Priority
+        const priority: Field = {
+            name: "priority",
+            label: Lng.gt("Priority"),
+            description: Lng.gt("PriorityDescription"),
+            isRequired: false,
+            input: {
+                type: "slider",
+                min: 0,
+                max: 3
+            }
+        };
+        form.fields.push(priority);
+
+        // Due Date
+        const dueDate: Field = {
+            name: "dueDate",
+            label: Lng.gt("DueDate"),
+            description: Lng.gt("DueDateDescription"),
+            isRequired: false,
+            input: {
+                type: "date"
+            }
+        };
+        form.fields.push(dueDate);
+
+        // Tags
+        const tags: Field = {
+            name: "tags",
+            label: Lng.gt("Tags"),
+            description: Lng.gt("TagsDescription"),
+            isRequired: false,
+            input: {
+                type: "tag"
+            }
+        };
+        form.fields.push(tags);
+
+        // Acronym
+        const acronym: Field = {
+            name: "acronym",
+            label: Lng.gt("Acronym"),
+            description: Lng.gt("AcronymDescription"),
+            isRequired: false,
+            input: {
+                type: "document_block",
+                body: "return app.plugins.plugins.prj.api.helper.generateAcronym(form.title);"
+            }
+        };
+        form.fields.push(acronym);
+
+        return form;
+    }
+
+    /**
+     * Registers the command to open the modal
+     * @remarks No cleanup needed
+     */
+    public static registerCommand(): void {
+        const global = Global.getInstance();
+        global.logger.trace("Registering 'CreateNewProjectModal' commands");
+        global.plugin.addCommand({
+            id: "create-new-project-file",
+            name: `${Lng.gt("New")} ${Lng.gt("Project")}`,
+            callback: async () => {
+                const modal = new CreateNewProjectModal();
+                const result = await modal.openForm();
+                if (result) {
+                    await modal.evaluateForm(result);
+                }
+            },
+        })
+    }
+
+}

--- a/src/libs/StaticModels/StaticDocumentModel.ts
+++ b/src/libs/StaticModels/StaticDocumentModel.ts
@@ -14,13 +14,13 @@ export class StaticDocumentModel {
      * @returns {DocumentModel[]} List of all documents
      */
     public static getAllDocuments(): DocumentModel[] {
-        const metadataCache = Global.getInstance().metadataCache.Cache;
+        const metadataCache = Global.getInstance().metadataCache.cache;
         const documents = metadataCache.filter(file => file.metadata?.frontmatter?.type === "Metadata").map(file => new DocumentModel(file.file));
         return documents;
     }
 
     public static getAllSenderRecipients(): string[] {
-        const metadataCache = Global.getInstance().metadataCache.Cache;
+        const metadataCache = Global.getInstance().metadataCache.cache;
         const documents = metadataCache.filter(file => file.metadata?.frontmatter?.type === "Metadata")
             .flatMap(file => [file.metadata?.frontmatter?.sender, file.metadata?.frontmatter?.recipient])
             .filter((v): v is string => v != null)
@@ -56,7 +56,7 @@ export class StaticDocumentModel {
      * - The function uses the metadataCache and fileCache to find all PDFs without a metadata file.
      */
     public static getAllPDFsWithoutMetadata(): TFile[] {
-        const metadataCache = Global.getInstance().metadataCache.Cache;
+        const metadataCache = Global.getInstance().metadataCache.cache;
         const fileCache = Global.getInstance().fileCache.Cache;
         const setOfPDFsWithMetadata = new Set(metadataCache
             .filter(file => file.metadata?.frontmatter?.type === "Metadata" && file.metadata?.frontmatter?.file)

--- a/src/libs/Tag.ts
+++ b/src/libs/Tag.ts
@@ -99,7 +99,7 @@ export default class Tag {
             tag = `#${tag}`;
         }
 
-        const existFile = this.metadataCache.Cache.find(file => {
+        const existFile = this.metadataCache.cache.find(file => {
             const tags = file.metadata?.frontmatter?.tags;
             if (typeof tags === 'string') {
                 return tags === tag;

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import GetMetadata from './libs/ContextMenus/GetMetadata';
 import API from './classes/API';
 import CreateNewMetadataModal from './libs/Modals/CreateNewMetadataModal';
 import ChangeStatusModal from './libs/Modals/ChangeStatusModal';
+import CreateNewProjectModal from './libs/Modals/CreateNewProjectModal';
 
 export default class Prj extends Plugin {
 	public settings: PrjSettings;
@@ -41,6 +42,9 @@ export default class Prj extends Plugin {
 
 		// Create New Metadata File Command
 		CreateNewMetadataModal.registerCommand();
+
+		// Create new Project Command
+		CreateNewProjectModal.registerCommand();
 
 		// Change Status Command
 		ChangeStatusModal.registerCommand();

--- a/src/models/BaseModel.ts
+++ b/src/models/BaseModel.ts
@@ -27,11 +27,10 @@ export class BaseModel<T extends object> extends TransactionModel<T> {
      */
     public set file(value: TFile) {
         if (this._file === undefined) {
+            this._file = value;
             super.setWriteChanges((update) => {
                 return this.setFrontmatter(update as Record<string, unknown>);
             });
-            this._file = value;
-            super.callWriteChanges();
         } else {
             this.logger.warn("File already set");
         }
@@ -96,6 +95,10 @@ export class BaseModel<T extends object> extends TransactionModel<T> {
         if (!frontmatter) {
             this.logger.trace('Creating empty object');
             const emptyObject = new this.ctor();
+            // Save the properties of the empty object to changes in transaction
+            for (const key in emptyObject) {
+                this.updateKeyValue(key, emptyObject[key]);
+            }
             this.dataProxy = this.createProxy(emptyObject) as T;
             return this.dataProxy;
         }

--- a/src/models/BaseModel.ts
+++ b/src/models/BaseModel.ts
@@ -216,6 +216,9 @@ export class BaseModel<T extends object> extends TransactionModel<T> {
         if (this.proxyMap.has(value as object)) {
             // If the value is a proxy, get the original value
             return this.proxyMap.get(value as object);
+        } else if (Array.isArray(value)) {
+            // If the value is an array, recursively check each element
+            return value.map(item => this.resolveProxyValue(item));
         } else if (value && typeof value === 'object') {
             // If the value is an object, recursively check the properties
             return Object.fromEntries(

--- a/src/models/PrjTaskManagementModel.ts
+++ b/src/models/PrjTaskManagementModel.ts
@@ -9,7 +9,7 @@ import TaskData from "src/types/TaskData";
 import TopicData from "src/types/TopicData";
 
 export class PrjTaskManagementModel<T extends IPrjData & IPrjTaskManagement> extends BaseModel<T> implements IPrjModel<T> {
-    constructor(file: TFile, ctor: new (data?: Partial<T>) => T) {
+    constructor(file: TFile | undefined, ctor: new (data?: Partial<T>) => T) {
         super(file, ctor, undefined);
     }
 

--- a/src/models/ProjectModel.ts
+++ b/src/models/ProjectModel.ts
@@ -4,7 +4,7 @@ import { PrjTaskManagementModel } from "./PrjTaskManagementModel";
 
 export class ProjectModel extends PrjTaskManagementModel<ProjectData> {
 
-    constructor(file: TFile) {
+    constructor(file: TFile | undefined) {
         super(file, ProjectData);
     }
 

--- a/src/models/TaskModel.ts
+++ b/src/models/TaskModel.ts
@@ -4,7 +4,7 @@ import { PrjTaskManagementModel } from "./PrjTaskManagementModel";
 
 export class TaskModel extends PrjTaskManagementModel<TaskData> {
 
-    constructor(file: TFile) {
+    constructor(file: TFile | undefined) {
         super(file, TaskData);
     }
 

--- a/src/models/TopicModel.ts
+++ b/src/models/TopicModel.ts
@@ -4,7 +4,7 @@ import { PrjTaskManagementModel } from "./PrjTaskManagementModel";
 
 export class TopicModel extends PrjTaskManagementModel<TopicData> {
 
-    constructor(file: TFile) {
+    constructor(file: TFile | undefined) {
         super(file, TopicData);
     }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -375,6 +375,13 @@
     margin-top: auto;
     margin-bottom: auto;
 }
+/** To display rendered Markdown correkt **/
+.editable-data-view.container ol {
+    white-space: normal;
+    line-height: var(--line-height-normal);
+    margin-top: auto;
+    margin-bottom: auto;
+}
 
 .editable-data-view.presentation-container,
 .editable-data-view.data-input-container,

--- a/src/types/DocumentData.ts
+++ b/src/types/DocumentData.ts
@@ -23,7 +23,10 @@ export default class DocumentData implements IPrjData, IPrjDocument {
     };
 
     constructor(data: Partial<DocumentData>) {
-        if (!data) return;
+        if (!data) {
+            this.type = "Metadata";
+            return;
+        }
         this.title = data.title !== undefined ? data.title : undefined;
         this.date = data.date !== undefined ? data.date : undefined;
         this.description = data.description !== undefined ? data.description : undefined;
@@ -35,7 +38,7 @@ export default class DocumentData implements IPrjData, IPrjDocument {
         this.relatedFiles = data.relatedFiles !== undefined ? data.relatedFiles : undefined;
         this.citationTitle = data.citationTitle !== undefined ? data.citationTitle : undefined;
         this.tags = data.tags !== undefined ? data.tags : undefined;
-        this.type = data.type !== undefined ? data.type : undefined;
+        this.type = data.type !== undefined ? data.type : "Metadata";
         this.subType = data.subType !== undefined ? data.subType : undefined;
         this.annotationTarget = data.annotationTarget !== undefined ? data.annotationTarget : undefined;
     }

--- a/src/types/ModalFormType.ts
+++ b/src/types/ModalFormType.ts
@@ -104,10 +104,15 @@ export type Field = {
     input: Input;
 }
 
-export type Input = TextInput | TextareaInput | DateInput | SelectInput | DataViewInput | ToggleInput | TagInput;
+export type Input = TextInput | TextareaInput | DateInput | DocumentBlock | SliderInput | SelectInput | DataViewInput | ToggleInput | TagInput;
 
 export type TextInput = {
     type: 'text';
+}
+
+export type DocumentBlock = {
+    type: 'document_block';
+    body: string;
 }
 
 export type TextareaInput = {
@@ -116,6 +121,12 @@ export type TextareaInput = {
 
 export type DateInput = {
     type: 'date';
+}
+
+export type SliderInput = {
+    type: 'slider';
+    min: number;
+    max: number;
 }
 
 export type SelectInput = {

--- a/src/types/PrjSettings.ts
+++ b/src/types/PrjSettings.ts
@@ -20,14 +20,18 @@ export interface PrjSettings {
         hideSymbol: string;
         clusterSymbol: string;
         defaultFolder: string;
+        template: string;
     };
     prjSettings: {
         topicSymbol: string;
         topicFolder: string;
+        topicTemplate: string;
         projectSymbol: string;
         projectFolder: string;
+        projectTemplate: string;
         taskSymbol: string;
         taskFolder: string;
+        taskTemplate: string;
     };
     baseTag: string;
     templateFolder: string;
@@ -54,16 +58,20 @@ export const DEFAULT_SETTINGS: PrjSettings = {
         "symbol": "file-text",
         "hideSymbol": "file-minus-2",
         "clusterSymbol": "library",
-        "defaultFolder": ""
+        "defaultFolder": "",
+        "template": ""
     },
     prjSettings: {
         "topicSymbol": "album",
-        "topicFolder": "Themen/",
+        "topicFolder": "Topics/",
+        "topicTemplate": "",
         "projectSymbol": "layout-list",
-        "projectFolder": "Projekte/",
+        "projectFolder": "Projects/",
+        "projectTemplate": "",
         "taskSymbol": "clipboard",
-        "taskFolder": "Aufgaben/"
+        "taskFolder": "Tasks/",
+        "taskTemplate": "",
     },
     baseTag: 'PRJ',
-    templateFolder: 'Vorlagen/'
+    templateFolder: 'Templates/'
 };

--- a/src/types/PrjSettings.ts
+++ b/src/types/PrjSettings.ts
@@ -23,8 +23,11 @@ export interface PrjSettings {
     };
     prjSettings: {
         topicSymbol: string;
+        topicFolder: string;
         projectSymbol: string;
+        projectFolder: string;
         taskSymbol: string;
+        taskFolder: string;
     };
     baseTag: string;
     templateFolder: string;
@@ -55,8 +58,11 @@ export const DEFAULT_SETTINGS: PrjSettings = {
     },
     prjSettings: {
         "topicSymbol": "album",
+        "topicFolder": "Themen/",
         "projectSymbol": "layout-list",
-        "taskSymbol": "clipboard"
+        "projectFolder": "Projekte/",
+        "taskSymbol": "clipboard",
+        "taskFolder": "Aufgaben/"
     },
     baseTag: 'PRJ',
     templateFolder: 'Vorlagen/'

--- a/src/types/ProjectData.ts
+++ b/src/types/ProjectData.ts
@@ -16,7 +16,10 @@ export default class ProjectData implements IPrjData, IPrjTaskManagement {
     aliases: string[] | null | undefined;
 
     constructor(data: Partial<ProjectData>) {
-        if (!data) return;
+        if (!data) {
+            this.type = "Project";
+            return;
+        }
         this.aliases = data.aliases !== undefined ? data.aliases : undefined;
         this.title = data.title !== undefined ? data.title : undefined;
         this.description = data.description !== undefined ? data.description : undefined;
@@ -25,7 +28,7 @@ export default class ProjectData implements IPrjData, IPrjTaskManagement {
         this.energy = data.energy !== undefined ? data.energy : undefined;
         this.due = data.due !== undefined ? data.due : undefined;
         this.tags = data.tags !== undefined ? data.tags : undefined;
-        this.type = data.type !== undefined ? data.type : undefined;
+        this.type = data.type !== undefined ? data.type : "Project";
         this.subType = data.subType !== undefined ? data.subType : undefined;
         this.history = data.history !== undefined ? data.history : undefined;
     }

--- a/src/types/ProjectData.ts
+++ b/src/types/ProjectData.ts
@@ -13,9 +13,11 @@ export default class ProjectData implements IPrjData, IPrjTaskManagement {
     due: string | null | undefined;
     tags: string[] | string | null | undefined;
     history: HistoryEntries | null | undefined;
+    aliases: string[] | null | undefined;
 
     constructor(data: Partial<ProjectData>) {
         if (!data) return;
+        this.aliases = data.aliases !== undefined ? data.aliases : undefined;
         this.title = data.title !== undefined ? data.title : undefined;
         this.description = data.description !== undefined ? data.description : undefined;
         this.status = data.status !== undefined ? data.status : undefined;
@@ -27,5 +29,6 @@ export default class ProjectData implements IPrjData, IPrjTaskManagement {
         this.subType = data.subType !== undefined ? data.subType : undefined;
         this.history = data.history !== undefined ? data.history : undefined;
     }
+
 
 }

--- a/src/types/TaskData.ts
+++ b/src/types/TaskData.ts
@@ -16,7 +16,10 @@ export default class TaskData implements IPrjData, IPrjTaskManagement {
     aliases: string[] | null | undefined;
 
     constructor(data: Partial<TaskData>) {
-        if (!data) return;
+        if (!data) {
+            this.type = "Task";
+            return;
+        }
         this.aliases = data.aliases !== undefined ? data.aliases : undefined;
         this.title = data.title !== undefined ? data.title : undefined;
         this.description = data.description !== undefined ? data.description : undefined;
@@ -25,7 +28,7 @@ export default class TaskData implements IPrjData, IPrjTaskManagement {
         this.energy = data.energy !== undefined ? data.energy : undefined;
         this.due = data.due !== undefined ? data.due : undefined;
         this.tags = data.tags !== undefined ? data.tags : undefined;
-        this.type = data.type !== undefined ? data.type : undefined;
+        this.type = data.type !== undefined ? data.type : "Task";
         this.subType = data.subType !== undefined ? data.subType : undefined;
         this.history = data.history !== undefined ? data.history : undefined;
     }

--- a/src/types/TaskData.ts
+++ b/src/types/TaskData.ts
@@ -13,9 +13,11 @@ export default class TaskData implements IPrjData, IPrjTaskManagement {
     due: string | null | undefined;
     tags: string[] | string | null | undefined;
     history: HistoryEntries | null | undefined;
+    aliases: string[] | null | undefined;
 
     constructor(data: Partial<TaskData>) {
         if (!data) return;
+        this.aliases = data.aliases !== undefined ? data.aliases : undefined;
         this.title = data.title !== undefined ? data.title : undefined;
         this.description = data.description !== undefined ? data.description : undefined;
         this.status = data.status !== undefined ? data.status : undefined;

--- a/src/types/TopicData.ts
+++ b/src/types/TopicData.ts
@@ -13,9 +13,11 @@ export default class TopicData implements IPrjData, IPrjTaskManagement {
     due: string | null | undefined;
     tags: string[] | string | null | undefined;
     history: HistoryEntries | null | undefined;
+    aliases: string[] | null | undefined;
 
     constructor(data: Partial<TopicData>) {
         if (!data) return;
+        this.aliases = data.aliases !== undefined ? data.aliases : undefined;
         this.title = data.title !== undefined ? data.title : undefined;
         this.description = data.description !== undefined ? data.description : undefined;
         this.status = data.status !== undefined ? data.status : undefined;

--- a/src/types/TopicData.ts
+++ b/src/types/TopicData.ts
@@ -16,7 +16,10 @@ export default class TopicData implements IPrjData, IPrjTaskManagement {
     aliases: string[] | null | undefined;
 
     constructor(data: Partial<TopicData>) {
-        if (!data) return;
+        if (!data) {
+            this.type = "Topic";
+            return;
+        }
         this.aliases = data.aliases !== undefined ? data.aliases : undefined;
         this.title = data.title !== undefined ? data.title : undefined;
         this.description = data.description !== undefined ? data.description : undefined;
@@ -25,7 +28,7 @@ export default class TopicData implements IPrjData, IPrjTaskManagement {
         this.energy = data.energy !== undefined ? data.energy : undefined;
         this.due = data.due !== undefined ? data.due : undefined;
         this.tags = data.tags !== undefined ? data.tags : undefined;
-        this.type = data.type !== undefined ? data.type : undefined;
+        this.type = data.type !== undefined ? data.type : "Topic";
         this.subType = data.subType !== undefined ? data.subType : undefined;
         this.history = data.history !== undefined ? data.history : undefined;
     }


### PR DESCRIPTION
dd4d2b1: 
# `BaseModel` 
- Corrected the order of file assignment. The data is now written correctly, as `_file` is present when the transaction class writes the changes down. - When creating an "empty" object, any existing fields are now written to the open transaction or directly.
# `CreateNewMetadataModal`
- The created file is now opened after the process.

# `CreateNewProjectModal`
- Any template is now used as a basis and the file is also opened after creation.

479e4e7: 
# `*Data` 
- All four data classes have been adapted so that the correct type certainly exists in them, unless it is specified.

4d0cb0d: 
# `ProjectComponents` 
- Changed the summary field to TextArea.
# `SearchInput`
- Added the possibility to specify a search text.

# `*BlockRenderComponent`
- Adjusted the logic accordingly so that the search field is retained even after a refresh.

4e5e868: 
# `Styles` 
- Added more places to optimize the display of Markdown in my tables for `ol` elements.
# `SettingTab` and `PrjSettings`
- Added settings for templates to the respective files.
- Added corresponding settings fields.
- Changed the language selection field to a dropdown field.

# `Helper`
- Added a method `openFile`, which opens a file and makes it visible.

# `MetadataCache`
- Changed the metadata cache array accessible via `get` to use the same array permanently.
- The private method `refreshMetadataCacheArray` is now called in the corresponding event handlers and updates the array, if necessary by emptying it and refilling it with the new data.
This ensures that the reference remains permanently the same.

# GetMetadata
- Switched to the `Helper.openFile` command.

dee115e: 
# `CreateNewProjectModal` 
- First version of the form for creating a new project.
# `Main`
- Corresponding command is registered.

cf00aab: 
# `PrjSettings` 
- Default folder for the project files added to the settings.

4e71839: 
# `ModalFormBase` 
- Class and file renamed. - Further modal form types added.

4666aa1: 
# `BaseModel` 
- Fixed a bug in the `resolveProxyValue` method which caused problems when adding a new array.

ab66220: 
# `PrjTaskManagementModel` etc... 
- Added the `aliases` field. - Added the option to start with an empty file.

aa965a9: 
# `MetadataCache` 
- The field `Cache` has been renamed correctly to `cache`.

2b62bc0: 
# `Helper` 
- Added a function to generate acronyms.

f4e902e: 
# `API` 
- The helper class is made available in the API.

2c49755: 
# `PrjTaskManagementModel` etc... 
- The `aliases` field has been inserted. 
- Added the option to start with an empty file.
