### PR TITLE
Integrate Prettier with ESLint for code formatting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,8 @@
     "env": { "node": true },
     "plugins": [
       "@typescript-eslint",
-      "deprecation"
+      "deprecation",
+      "prettier"
     ],
     "extends": [
       "eslint:recommended",
@@ -16,6 +17,7 @@
         "project": "./tsconfig.json"
     },
     "rules": {
+      "prettier/prettier": "error",
       "no-unused-vars": "off",
       "@typescript-eslint/no-unused-vars": ["error", { "args": "none" }],
       "@typescript-eslint/ban-ts-comment": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -18,11 +18,42 @@
     },
     "rules": {
       "prettier/prettier": "error",
+      "array-callback-return": ["error"],
+      "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_",
+        "args": "none"
+      }
+    ],
       "no-unused-vars": "off",
-      "@typescript-eslint/no-unused-vars": ["error", { "args": "none" }],
       "@typescript-eslint/ban-ts-comment": "off",
       "no-prototype-builtins": "off",
       "@typescript-eslint/no-empty-function": "off",
-      "deprecation/deprecation": "error"
+      "deprecation/deprecation": "error",
+      "no-console": "error",
+      "@typescript-eslint/padding-line-between-statements": [
+      "warn",
+      {
+        "blankLine": "always",
+        "prev": "*",
+        "next": [
+          "return",
+          "if",
+          "multiline-const",
+          "function",
+          "multiline-expression",
+          "multiline-let",
+          "block-like"
+        ]
+      },
+      {
+        "blankLine": "always",
+        "prev": ["function"],
+        "next": "*"
+      }
+    ]
     } 
   }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,14 @@
+{
+  "printWidth": 80,
+  "semi": true,
+  "singleQuote": true,
+  "bracketSpacing": true,
+  "useTabs": false,
+  "endOfLine": "auto",
+  "overrides": [
+    {
+      "files": [".prettierrc", ".eslintrc"],
+      "options": { "parser": "json" }
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "obsidian-sample-plugin",
-  "version": "0.0.30",
+  "version": "0.0.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-sample-plugin",
-      "version": "0.0.30",
+      "version": "0.0.41",
       "license": "MIT",
       "dependencies": {
         "crypto-js": "^4.2.0",
+        "eslint-plugin-prettier": "^5.1.3",
         "js-yaml": "^4.1.0"
       },
       "devDependencies": {
@@ -55,7 +56,6 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -448,7 +448,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
       "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
-      "dev": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.3.0"
       },
@@ -463,7 +462,6 @@
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
       "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -473,7 +471,6 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
       "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -497,7 +494,6 @@
       "version": "8.56.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
       "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -513,7 +509,6 @@
       "version": "0.11.13",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
       "integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^2.0.1",
@@ -528,7 +523,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=12.22"
@@ -542,7 +536,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
       "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
-      "dev": true,
       "peer": true
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -606,7 +599,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -619,7 +611,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -628,13 +619,23 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -909,7 +910,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-      "dev": true,
       "peer": true
     },
     "node_modules/abort-controller": {
@@ -928,7 +928,6 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -940,7 +939,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
       "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -959,7 +957,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -976,7 +973,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -985,7 +981,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1041,8 +1036,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1077,7 +1071,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1141,7 +1134,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -1151,7 +1143,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -1241,7 +1232,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1252,8 +1242,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/command-line-args": {
       "version": "5.2.1",
@@ -1306,8 +1295,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -1328,7 +1316,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1348,7 +1335,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1365,7 +1351,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true,
       "peer": true
     },
     "node_modules/diff": {
@@ -1393,7 +1378,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "esutils": "^2.0.2"
@@ -1458,7 +1442,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -1471,7 +1454,6 @@
       "version": "8.56.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
       "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -1662,6 +1644,35 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz",
+      "integrity": "sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.6"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": "*",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -1706,7 +1717,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -1718,7 +1728,6 @@
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
       "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -1735,7 +1744,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=4.0"
@@ -1745,7 +1753,6 @@
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "acorn": "^8.9.0",
@@ -1763,7 +1770,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
       "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -1776,7 +1782,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=4.0"
@@ -1786,7 +1791,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -1798,7 +1802,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -1816,7 +1819,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1844,8 +1846,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "peer": true
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -1879,21 +1885,18 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "peer": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true,
       "peer": true
     },
     "node_modules/fastq": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
       "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
-      "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -1902,7 +1905,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "flat-cache": "^3.0.4"
@@ -1939,7 +1941,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -1956,7 +1957,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
       "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
@@ -1971,14 +1971,12 @@
       "version": "3.2.9",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
-      "dev": true,
       "peer": true
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2013,7 +2011,6 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2033,7 +2030,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -2046,7 +2042,6 @@
       "version": "13.24.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
       "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -2082,7 +2077,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
       "peer": true
     },
     "node_modules/graphql": {
@@ -2098,7 +2092,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2127,7 +2120,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
       "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
-      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -2142,7 +2134,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -2159,7 +2150,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=0.8.19"
@@ -2169,7 +2159,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -2178,8 +2167,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -2197,7 +2185,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2215,7 +2202,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -2236,7 +2222,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -2252,7 +2237,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "peer": true
     },
     "node_modules/iterall": {
@@ -2282,28 +2266,24 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
       "peer": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
       "peer": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true,
       "peer": true
     },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -2313,7 +2293,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -2327,7 +2306,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -2361,7 +2339,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
       "peer": true
     },
     "node_modules/lru-cache": {
@@ -2417,7 +2394,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2437,14 +2413,12 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true,
       "peer": true
     },
     "node_modules/node-fetch": {
@@ -2558,7 +2532,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2567,7 +2540,6 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
       "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "@aashutoshrathi/word-wrap": "^1.2.3",
@@ -2585,7 +2557,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -2601,7 +2572,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -2629,7 +2599,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "callsites": "^3.0.0"
@@ -2654,7 +2623,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -2664,7 +2632,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2673,7 +2640,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -2723,10 +2689,35 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
+      "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
+      "peer": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/process": {
@@ -2742,7 +2733,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -2752,7 +2742,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2938,7 +2927,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=4"
@@ -2948,7 +2936,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -2958,7 +2945,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
@@ -2974,7 +2960,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3058,7 +3043,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3071,7 +3055,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -3175,7 +3158,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -3187,7 +3169,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -3207,7 +3188,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -3223,6 +3203,26 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/synckit": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
+      "integrity": "sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==",
+      "dependencies": {
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/synckit/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/table-layout": {
       "version": "3.0.2",
@@ -3267,7 +3267,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true,
       "peer": true
     },
     "node_modules/tiny-inflate": {
@@ -3380,7 +3379,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -3393,7 +3391,6 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -3454,7 +3451,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
@@ -3505,7 +3501,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
@@ -3552,8 +3547,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -3619,7 +3613,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "crypto-js": "^4.2.0",
+    "eslint-plugin-prettier": "^5.1.3",
     "js-yaml": "^4.1.0"
   }
 }

--- a/src/classes/API.ts
+++ b/src/classes/API.ts
@@ -1,7 +1,7 @@
-import Global from "src/classes/Global";
-import Helper from "src/libs/Helper";
-import { StaticDocumentModel } from "src/models/StaticHelper/StaticDocumentModel";
-import { StaticPrjTaskManagementModel } from "src/models/StaticHelper/StaticPrjTaskManagementModel";
+import Global from 'src/classes/Global';
+import Helper from 'src/libs/Helper';
+import { StaticDocumentModel } from 'src/models/StaticHelper/StaticDocumentModel';
+import { StaticPrjTaskManagementModel } from 'src/models/StaticHelper/StaticPrjTaskManagementModel';
 
 export default class API {
     public static get global(): Global {
@@ -10,5 +10,4 @@ export default class API {
     public static documentModel = StaticDocumentModel;
     public static prjTaskManagementModel = StaticPrjTaskManagementModel;
     public static helper = Helper;
-
 }

--- a/src/classes/Global.ts
+++ b/src/classes/Global.ts
@@ -1,7 +1,7 @@
 import { PrjSettings } from 'src/types/PrjSettings';
-import { App } from "obsidian";
-import FileCache from "../libs/FileCache";
-import MetadataCache from "../libs/MetadataCache";
+import { App } from 'obsidian';
+import FileCache from '../libs/FileCache';
+import MetadataCache from '../libs/MetadataCache';
 import Logging, { LoggingLevel } from './Logging';
 import Prj from 'src/main';
 
@@ -26,7 +26,10 @@ export default class Global {
         // Settings
         this.settings = settings;
 
-        this.logger = new Logging(this.settings.logLevel as LoggingLevel, "Prj");
+        this.logger = new Logging(
+            this.settings.logLevel as LoggingLevel,
+            'Prj',
+        );
 
         // Singleton; before creating the cache instances, because they need the app instance
         Global.instance = this;
@@ -36,14 +39,13 @@ export default class Global {
 
         // Metadata cache
         this.metadataCache = MetadataCache.getInstance();
-
     }
 
     public async awaitCacheInitialization() {
-        this.logger.debug("Waiting for cache initialization");
+        this.logger.debug('Waiting for cache initialization');
         await this.fileCache.waitForCacheReady();
         await this.metadataCache.waitForCacheReady();
-        this.logger.debug("Cache initialized");
+        this.logger.debug('Cache initialized');
     }
 
     public static deconstructor() {
@@ -51,13 +53,20 @@ export default class Global {
         MetadataCache.deconstructor();
     }
 
-    static getInstance(prj: Prj | null = null, app: App | null = null, settings: PrjSettings | null = null): Global {
+    static getInstance(
+        prj: Prj | null = null,
+        app: App | null = null,
+        settings: PrjSettings | null = null,
+    ): Global {
         if (!Global.instance) {
             if (!prj || !app || !settings) {
-                throw new Error("Global instance not initialized and no app provided");
+                throw new Error(
+                    'Global instance not initialized and no app provided',
+                );
             }
             Global.instance = new Global(prj, app, settings);
         }
+
         return Global.instance;
     }
 }

--- a/src/classes/Lng.ts
+++ b/src/classes/Lng.ts
@@ -1,5 +1,5 @@
 import Translations from '../translations/translations.json';
-import Global from "./Global";
+import Global from './Global';
 
 export default class Lng {
     /**
@@ -10,16 +10,18 @@ export default class Lng {
      * - Look at the `translations.json` file to see all available translations.
      */
     public static gt(key: string): string {
-        const logger = Global.getInstance().logger
+        const logger = Global.getInstance().logger;
         const lang = Global.getInstance().settings.language;
-        const translation = (Translations as Translations);
+        const translation = Translations as Translations;
         const language = translation.find((v) => v.lang === lang);
+
         if (language) {
             if (language.translations.hasOwnProperty(key)) {
                 return language.translations[key] as string;
             }
         }
         logger.warn(`Translation for key ${key} not found`);
+
         return key;
     }
 }

--- a/src/classes/Logging.ts
+++ b/src/classes/Logging.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { ILogger } from "src/interfaces/ILogger";
+import { ILogger } from 'src/interfaces/ILogger';
 
 /**
  * Logging class; encapsulates console.log, console.debug, console.warn and console.error
@@ -14,17 +14,20 @@ export default class Logging implements ILogger {
      * Creates a new Logging instance
      * @param logLevel The log level to use. Defaults to "info"
      */
-    constructor(logLevel: LoggingLevel = "info", logPrefix = "") {
+    constructor(logLevel: LoggingLevel = 'info', logPrefix = '') {
         this.logLevel = logLevel;
         this.logPrefix = `${logPrefix}-`;
-        if (this.logLevel === "none") {
-            console.info("Logging disabled");
+
+        if (this.logLevel === 'none') {
+            // eslint-disable-next-line no-console
+            console.info('Logging disabled');
         }
         Logging.instance = this;
     }
 
     public setLogLevel(logLevel: LoggingLevel) {
         this.logLevel = logLevel;
+        // eslint-disable-next-line no-console
         console.info(`Log level set to ${logLevel}`);
     }
 
@@ -35,6 +38,7 @@ export default class Logging implements ILogger {
         if (!Logging.instance) {
             Logging.instance = new Logging();
         }
+
         return Logging.instance;
     }
 
@@ -45,12 +49,20 @@ export default class Logging implements ILogger {
     public static getLogger(prefix: string): ILogger {
         const instance = Logging.getInstance();
         prefix = `${prefix}: `;
-        const logMethods: { [key in Exclude<LoggingLevel, "none">]: (...args: any[]) => void } = {
-            trace: (...args: any[]) => instance.logWithPrefix("trace", prefix, args),
-            debug: (...args: any[]) => instance.logWithPrefix("debug", prefix, args),
-            info: (...args: any[]) => instance.logWithPrefix("info", prefix, args),
-            warn: (...args: any[]) => instance.logWithPrefix("warn", prefix, args),
-            error: (...args: any[]) => instance.logWithPrefix("error", prefix, args),
+
+        const logMethods: {
+            [key in Exclude<LoggingLevel, 'none'>]: (...args: any[]) => void;
+        } = {
+            trace: (...args: any[]) =>
+                instance.logWithPrefix('trace', prefix, args),
+            debug: (...args: any[]) =>
+                instance.logWithPrefix('debug', prefix, args),
+            info: (...args: any[]) =>
+                instance.logWithPrefix('info', prefix, args),
+            warn: (...args: any[]) =>
+                instance.logWithPrefix('warn', prefix, args),
+            error: (...args: any[]) =>
+                instance.logWithPrefix('error', prefix, args),
         };
 
         return logMethods;
@@ -58,72 +70,81 @@ export default class Logging implements ILogger {
 
     /**
      * Logs a message with a specified prefix and level.
-     * 
+     *
      * @param level - The logging level.
      * @param prefix - The prefix to add to the log message.
      * @param args - The arguments to be logged.
      */
-    private logWithPrefix(level: Exclude<LoggingLevel, "none">, prefix: string, args: any[]) {
+    private logWithPrefix(
+        level: Exclude<LoggingLevel, 'none'>,
+        prefix: string,
+        args: any[],
+    ) {
         args.unshift(prefix);
         (this[level] as (...args: any[]) => void)(...args);
     }
 
     /**
      * Logs a message to the console if the log level is "trace"
-     * @param message 
-     * @param optionalParams 
+     * @param message
+     * @param optionalParams
      */
     public trace(message?: any, ...optionalParams: any[]): void {
-        if (this.logLevelActive("trace")) {
+        if (this.logLevelActive('trace')) {
             const logMessage = this.constructLogMessage(message);
+            // eslint-disable-next-line no-console
             console.debug(logMessage, ...optionalParams);
         }
     }
 
     /**
      * Logs a message to the console if the log level is "debug"
-     * @param message 
-     * @param optionalParams 
+     * @param message
+     * @param optionalParams
      */
     public debug(message?: any, ...optionalParams: any[]): void {
-        if (this.logLevelActive("debug")) {
+        if (this.logLevelActive('debug')) {
             const logMessage = this.constructLogMessage(message);
+            // eslint-disable-next-line no-console
             console.debug(logMessage, ...optionalParams);
         }
     }
 
     /**
      * Logs a message to the console if the log level is "info" or "debug"
-     * @param message 
-     * @param optionalParams 
+     * @param message
+     * @param optionalParams
      */
     public info(message?: any, ...optionalParams: any[]): void {
-        if (this.logLevelActive("info")) {
+        if (this.logLevelActive('info')) {
             const logMessage = this.constructLogMessage(message);
+            // eslint-disable-next-line no-console
             console.info(logMessage, ...optionalParams);
         }
     }
 
     /**
      * Logs a message to the console if the log level is "info", "debug" or "warn"
-     * @param message 
-     * @param optionalParams 
+     * @param message
+     * @param optionalParams
      */
     public warn(message?: any, ...optionalParams: any[]): void {
-        if (this.logLevelActive("warn")) {
+        if (this.logLevelActive('warn')) {
             const logMessage = this.constructLogMessage(message);
+            // eslint-disable-next-line no-console
             console.warn(logMessage, ...optionalParams);
         }
     }
 
     /**
      * Logs a message to the console if the log level is "info", "debug", "warn" or "error"
-     * @param message 
-     * @param optionalParams 
+     * @param message
+     * @param optionalParams
      */
     public error(message?: any, ...optionalParams: any[]): void {
-        if (this.logLevelActive("error")) {
+        if (this.logLevelActive('error')) {
             const logMessage = this.constructLogMessage(message);
+            // eslint-disable-next-line no-console
             console.error(logMessage, ...optionalParams);
         }
     }
@@ -133,26 +154,47 @@ export default class Logging implements ILogger {
     }
 
     private logLevelActive(logLevel: LoggingLevel): boolean {
-        if (this.logLevel === "none") {
+        if (this.logLevel === 'none') {
             return false;
         }
-        if (this.logLevel === "trace") {
+
+        if (this.logLevel === 'trace') {
             return true;
         }
-        if (this.logLevel === "debug") {
-            return logLevel !== "trace";
+
+        if (this.logLevel === 'debug') {
+            return logLevel !== 'trace';
         }
-        if (this.logLevel === "info") {
-            return logLevel !== "trace" && logLevel !== "debug";
+
+        if (this.logLevel === 'info') {
+            return logLevel !== 'trace' && logLevel !== 'debug';
         }
-        if (this.logLevel === "warn") {
-            return logLevel !== "trace" && logLevel !== "debug" && logLevel !== "info";
+
+        if (this.logLevel === 'warn') {
+            return (
+                logLevel !== 'trace' &&
+                logLevel !== 'debug' &&
+                logLevel !== 'info'
+            );
         }
-        if (this.logLevel === "error") {
-            return logLevel !== "trace" && logLevel !== "debug" && logLevel !== "info" && logLevel !== "warn";
+
+        if (this.logLevel === 'error') {
+            return (
+                logLevel !== 'trace' &&
+                logLevel !== 'debug' &&
+                logLevel !== 'info' &&
+                logLevel !== 'warn'
+            );
         }
+
         return true;
     }
 }
 
-export type LoggingLevel = "none" | "trace" | "debug" | "info" | "warn" | "error";
+export type LoggingLevel =
+    | 'none'
+    | 'trace'
+    | 'debug'
+    | 'info'
+    | 'warn'
+    | 'error';

--- a/src/classes/SettingsTab.ts
+++ b/src/classes/SettingsTab.ts
@@ -3,7 +3,6 @@ import Prj from 'src/main';
 import Global from './Global';
 import { LoggingLevel } from './Logging';
 
-
 export class SettingTab extends PluginSettingTab {
     plugin: Prj;
 
@@ -21,409 +20,488 @@ export class SettingTab extends PluginSettingTab {
         new Setting(containerEl)
             .setName('Log Level')
             .setDesc('The log level to use')
-            .addDropdown(dropdown => dropdown
-                .addOptions({
-                    'none': 'none',
-                    'trace': 'trace',
-                    'debug': 'debug',
-                    'info': 'info',
-                    'warn': 'warn',
-                    'error': 'error'
-                })
-                .setValue(this.plugin.settings.logLevel)
-                .onChange(async (value) => {
-                    this.plugin.settings.logLevel = value;
-                    Global.getInstance().logger.setLogLevel(value as LoggingLevel);
-                    await this.plugin.saveSettings();
-                }));
+            .addDropdown((dropdown) =>
+                dropdown
+                    .addOptions({
+                        none: 'none',
+                        trace: 'trace',
+                        debug: 'debug',
+                        info: 'info',
+                        warn: 'warn',
+                        error: 'error',
+                    })
+                    .setValue(this.plugin.settings.logLevel)
+                    .onChange(async (value) => {
+                        this.plugin.settings.logLevel = value;
+
+                        Global.getInstance().logger.setLogLevel(
+                            value as LoggingLevel,
+                        );
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Editability
         new Setting(containerEl)
             .setName('Performance Mode (only Mobile)')
-            .setDesc('The performance of the plugin is affected by this setting. If disabled, the editability of the blocks is disabled. No effect on Desktop!')
-            .addToggle(toggle => toggle
-                .setValue(this.plugin.settings.mobile)
-                .onChange(async (value) => {
-                    this.plugin.settings.mobile = value;
-                    await this.plugin.saveSettings();
-                }));
+            .setDesc(
+                'The performance of the plugin is affected by this setting. If disabled, the editability of the blocks is disabled. No effect on Desktop!',
+            )
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(this.plugin.settings.mobile)
+                    .onChange(async (value) => {
+                        this.plugin.settings.mobile = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Localisation
-        new Setting(containerEl)
-            .setHeading()
-            .setName('Localisation');
+        new Setting(containerEl).setHeading().setName('Localisation');
 
         // Language (Dropdown)
         new Setting(containerEl)
             .setName('Language')
             .setDesc('The language to use')
-            .addDropdown(dropdown => dropdown
-                .addOptions({
-                    'en': 'English',
-                    'de': 'Deutsch'
-                })
-                .setValue(this.plugin.settings.language)
-                .onChange(async (value) => {
-                    this.plugin.settings.language = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addDropdown((dropdown) =>
+                dropdown
+                    .addOptions({
+                        en: 'English',
+                        de: 'Deutsch',
+                    })
+                    .setValue(this.plugin.settings.language)
+                    .onChange(async (value) => {
+                        this.plugin.settings.language = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Date format
         new Setting(containerEl)
             .setName('Date Format')
             .setDesc('The Date format to use')
-            .addText(text => text
-                .setPlaceholder('DD.MM.YYYY')
-                .setValue(this.plugin.settings.dateFormat)
-                .onChange(async (value) => {
-                    this.plugin.settings.dateFormat = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('DD.MM.YYYY')
+                    .setValue(this.plugin.settings.dateFormat)
+                    .onChange(async (value) => {
+                        this.plugin.settings.dateFormat = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Date format short
         new Setting(containerEl)
             .setName('Short date format')
             .setDesc('The short Date format to use')
-            .addText(text => text
-                .setPlaceholder('DD.MM.YY')
-                .setValue(this.plugin.settings.dateFormatShort)
-                .onChange(async (value) => {
-                    this.plugin.settings.dateFormatShort = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('DD.MM.YY')
+                    .setValue(this.plugin.settings.dateFormatShort)
+                    .onChange(async (value) => {
+                        this.plugin.settings.dateFormatShort = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Base tag for all related files
         new Setting(containerEl)
             .setName('Base Tag')
             .setDesc('The Base Tag for all Elements')
-            .addText(text => text
-                .setPlaceholder('YourBaseTag (without / and #)')
-                .setValue(this.plugin.settings.baseTag)
-                .onChange(async (value) => {
-                    this.plugin.settings.baseTag = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('YourBaseTag (without / and #)')
+                    .setValue(this.plugin.settings.baseTag)
+                    .onChange(async (value) => {
+                        this.plugin.settings.baseTag = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Template Folder
         new Setting(containerEl)
             .setName('Template Folder')
             .setDesc('The Folder where all Templates are stored')
-            .addText(text => text
-                .setPlaceholder('YourTemplateFolder')
-                .setValue(this.plugin.settings.templateFolder)
-                .onChange(async (value) => {
-                    this.plugin.settings.templateFolder = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('YourTemplateFolder')
+                    .setValue(this.plugin.settings.templateFolder)
+                    .onChange(async (value) => {
+                        this.plugin.settings.templateFolder = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // PDF Folder
         new Setting(containerEl)
             .setName('PDF Folder')
-            .setDesc('The Folder where all PDFs are stored. {YYYY} is replaced with the current year and {MM} with the current month.')
-            .addText(text => text
-                .setPlaceholder('YourPDFFolder')
-                .setValue(this.plugin.settings.documentSettings.pdfFolder)
-                .onChange(async (value) => {
-                    this.plugin.settings.documentSettings.pdfFolder = value;
-                    await this.plugin.saveSettings();
-                }));
+            .setDesc(
+                'The Folder where all PDFs are stored. {YYYY} is replaced with the current year and {MM} with the current month.',
+            )
+            .addText((text) =>
+                text
+                    .setPlaceholder('YourPDFFolder')
+                    .setValue(this.plugin.settings.documentSettings.pdfFolder)
+                    .onChange(async (value) => {
+                        this.plugin.settings.documentSettings.pdfFolder = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // User information
-        new Setting(containerEl)
-            .setHeading()
-            .setName('User Information');
+        new Setting(containerEl).setHeading().setName('User Information');
 
         // User Name
         new Setting(containerEl)
             .setName('User: Name')
             .setDesc('Your name')
-            .addText(text => text
-                .setPlaceholder('Your name')
-                .setValue(this.plugin.settings.user.name)
-                .onChange(async (value) => {
-                    this.plugin.settings.user.name = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('Your name')
+                    .setValue(this.plugin.settings.user.name)
+                    .onChange(async (value) => {
+                        this.plugin.settings.user.name = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // User Name Short
         new Setting(containerEl)
             .setName('User: Short name')
             .setDesc('Your name short name')
-            .addText(text => text
-                .setPlaceholder('Your name shortened')
-                .setValue(this.plugin.settings.user.shortName)
-                .onChange(async (value) => {
-                    this.plugin.settings.user.shortName = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('Your name shortened')
+                    .setValue(this.plugin.settings.user.shortName)
+                    .onChange(async (value) => {
+                        this.plugin.settings.user.shortName = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // User Email
         new Setting(containerEl)
             .setName('User: Email')
             .setDesc('Your E-Mail adress')
-            .addText(text => text
-                .setPlaceholder('Your email')
-                .setValue(this.plugin.settings.user.email)
-                .onChange(async (value) => {
-                    this.plugin.settings.user.email = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('Your email')
+                    .setValue(this.plugin.settings.user.email)
+                    .onChange(async (value) => {
+                        this.plugin.settings.user.email = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // User Street
         new Setting(containerEl)
             .setName('User: Street')
             .setDesc('Your street')
-            .addText(text => text
-                .setPlaceholder('Your street')
-                .setValue(this.plugin.settings.user.street)
-                .onChange(async (value) => {
-                    this.plugin.settings.user.street = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('Your street')
+                    .setValue(this.plugin.settings.user.street)
+                    .onChange(async (value) => {
+                        this.plugin.settings.user.street = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // User City
         new Setting(containerEl)
             .setName('User: City')
             .setDesc('Your city')
-            .addText(text => text
-                .setPlaceholder('Your city')
-                .setValue(this.plugin.settings.user.city)
-                .onChange(async (value) => {
-                    this.plugin.settings.user.city = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('Your city')
+                    .setValue(this.plugin.settings.user.city)
+                    .onChange(async (value) => {
+                        this.plugin.settings.user.city = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // User Zip
         new Setting(containerEl)
             .setName('User: Zip Code')
             .setDesc('Your zip code')
-            .addText(text => text
-                .setPlaceholder('Your zip')
-                .setValue(this.plugin.settings.user.zip)
-                .onChange(async (value) => {
-                    this.plugin.settings.user.zip = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('Your zip')
+                    .setValue(this.plugin.settings.user.zip)
+                    .onChange(async (value) => {
+                        this.plugin.settings.user.zip = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // User Country
         new Setting(containerEl)
             .setName('User: Country')
             .setDesc('Your country')
-            .addText(text => text
-                .setPlaceholder('Your country')
-                .setValue(this.plugin.settings.user.country)
-                .onChange(async (value) => {
-                    this.plugin.settings.user.country = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('Your country')
+                    .setValue(this.plugin.settings.user.country)
+                    .onChange(async (value) => {
+                        this.plugin.settings.user.country = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Document Settings
-        new Setting(containerEl)
-            .setHeading()
-            .setName('Document Settings');
+        new Setting(containerEl).setHeading().setName('Document Settings');
 
         // Default Max Show
         new Setting(containerEl)
             .setName('Default Max Show')
             .setDesc('The default max show for Table Entrys')
-            .addText(text => text
-                .setPlaceholder('200')
-                .setValue(this.plugin.settings.defaultMaxShow.toString())
-                .onChange(async (value) => {
-                    this.plugin.settings.defaultMaxShow = value as unknown as number;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('200')
+                    .setValue(this.plugin.settings.defaultMaxShow.toString())
+                    .onChange(async (value) => {
+                        this.plugin.settings.defaultMaxShow =
+                            value as unknown as number;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Symbol
         new Setting(containerEl)
             .setName('Document Symbol')
             .setDesc('The Symbol for regular Documents')
-            .addText(text => text
-                .setPlaceholder('file-text')
-                .setValue(this.plugin.settings.documentSettings.symbol)
-                .onChange(async (value) => {
-                    this.plugin.settings.documentSettings.symbol = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('file-text')
+                    .setValue(this.plugin.settings.documentSettings.symbol)
+                    .onChange(async (value) => {
+                        this.plugin.settings.documentSettings.symbol = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Hide Symbol
         new Setting(containerEl)
             .setName('Hide Symbol')
             .setDesc('The Symbol for hidden Documents')
-            .addText(text => text
-                .setPlaceholder('file-minus-2')
-                .setValue(this.plugin.settings.documentSettings.hideSymbol)
-                .onChange(async (value) => {
-                    this.plugin.settings.documentSettings.hideSymbol = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('file-minus-2')
+                    .setValue(this.plugin.settings.documentSettings.hideSymbol)
+                    .onChange(async (value) => {
+                        this.plugin.settings.documentSettings.hideSymbol =
+                            value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Cluster Symbol
         new Setting(containerEl)
             .setName('Cluster Symbol')
             .setDesc('The Symbol for Cluster Documents')
-            .addText(text => text
-                .setPlaceholder('library')
-                .setValue(this.plugin.settings.documentSettings.clusterSymbol)
-                .onChange(async (value) => {
-                    this.plugin.settings.documentSettings.clusterSymbol = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('library')
+                    .setValue(
+                        this.plugin.settings.documentSettings.clusterSymbol,
+                    )
+                    .onChange(async (value) => {
+                        this.plugin.settings.documentSettings.clusterSymbol =
+                            value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Default Folder
         new Setting(containerEl)
             .setName('Default Folder')
             .setDesc('The default folder for new Documents')
-            .addText(text => text
-                .setPlaceholder('')
-                .setValue(this.plugin.settings.documentSettings.defaultFolder)
-                .onChange(async (value) => {
-                    this.plugin.settings.documentSettings.defaultFolder = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('')
+                    .setValue(
+                        this.plugin.settings.documentSettings.defaultFolder,
+                    )
+                    .onChange(async (value) => {
+                        this.plugin.settings.documentSettings.defaultFolder =
+                            value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Template file
         new Setting(containerEl)
             .setName('Template File')
             .setDesc('The Template file for new Documents')
-            .addText(text => text
-                .setPlaceholder('')
-                .setValue(this.plugin.settings.documentSettings.template)
-                .onChange(async (value) => {
-                    this.plugin.settings.documentSettings.template = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('')
+                    .setValue(this.plugin.settings.documentSettings.template)
+                    .onChange(async (value) => {
+                        this.plugin.settings.documentSettings.template = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Project Settings
-        new Setting(containerEl)
-            .setHeading()
-            .setName('Project Settings');
+        new Setting(containerEl).setHeading().setName('Project Settings');
 
         // Topic Symbol
         new Setting(containerEl)
             .setName('Topic Symbol')
             .setDesc('The Symbol for Topics')
-            .addText(text => text
-                .setPlaceholder('album')
-                .setValue(this.plugin.settings.prjSettings.topicSymbol)
-                .onChange(async (value) => {
-                    this.plugin.settings.prjSettings.topicSymbol = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('album')
+                    .setValue(this.plugin.settings.prjSettings.topicSymbol)
+                    .onChange(async (value) => {
+                        this.plugin.settings.prjSettings.topicSymbol = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Topic Folder
         new Setting(containerEl)
             .setName('Topic Folder')
             .setDesc('The default folder for new Topics')
-            .addText(text => text
-                .setPlaceholder('')
-                .setValue(this.plugin.settings.prjSettings.topicFolder)
-                .onChange(async (value) => {
-                    this.plugin.settings.prjSettings.topicFolder = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('')
+                    .setValue(this.plugin.settings.prjSettings.topicFolder)
+                    .onChange(async (value) => {
+                        this.plugin.settings.prjSettings.topicFolder = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Template file
         new Setting(containerEl)
             .setName('Template File')
             .setDesc('The Template file for new Topics')
-            .addText(text => text
-                .setPlaceholder('')
-                .setValue(this.plugin.settings.prjSettings.topicTemplate)
-                .onChange(async (value) => {
-                    this.plugin.settings.prjSettings.topicTemplate = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('')
+                    .setValue(this.plugin.settings.prjSettings.topicTemplate)
+                    .onChange(async (value) => {
+                        this.plugin.settings.prjSettings.topicTemplate = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Project Symbol
         new Setting(containerEl)
             .setName('Project Symbol')
             .setDesc('The Symbol for Projects')
-            .addText(text => text
-                .setPlaceholder('album')
-                .setValue(this.plugin.settings.prjSettings.projectSymbol)
-                .onChange(async (value) => {
-                    this.plugin.settings.prjSettings.projectSymbol = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('album')
+                    .setValue(this.plugin.settings.prjSettings.projectSymbol)
+                    .onChange(async (value) => {
+                        this.plugin.settings.prjSettings.projectSymbol = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Project Folder
         new Setting(containerEl)
             .setName('Project Folder')
             .setDesc('The default folder for new Projects')
-            .addText(text => text
-                .setPlaceholder('')
-                .setValue(this.plugin.settings.prjSettings.projectFolder)
-                .onChange(async (value) => {
-                    this.plugin.settings.prjSettings.projectFolder = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('')
+                    .setValue(this.plugin.settings.prjSettings.projectFolder)
+                    .onChange(async (value) => {
+                        this.plugin.settings.prjSettings.projectFolder = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Template file
         new Setting(containerEl)
             .setName('Template File')
             .setDesc('The Template file for new Projects')
-            .addText(text => text
-                .setPlaceholder('')
-                .setValue(this.plugin.settings.prjSettings.projectTemplate)
-                .onChange(async (value) => {
-                    this.plugin.settings.prjSettings.projectTemplate = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('')
+                    .setValue(this.plugin.settings.prjSettings.projectTemplate)
+                    .onChange(async (value) => {
+                        this.plugin.settings.prjSettings.projectTemplate =
+                            value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Task Symbol
         new Setting(containerEl)
             .setName('Task Symbol')
             .setDesc('The Symbol for Tasks')
-            .addText(text => text
-                .setPlaceholder('album')
-                .setValue(this.plugin.settings.prjSettings.taskSymbol)
-                .onChange(async (value) => {
-                    this.plugin.settings.prjSettings.taskSymbol = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('album')
+                    .setValue(this.plugin.settings.prjSettings.taskSymbol)
+                    .onChange(async (value) => {
+                        this.plugin.settings.prjSettings.taskSymbol = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Task Folder
         new Setting(containerEl)
             .setName('Task Folder')
             .setDesc('The default folder for new Tasks')
-            .addText(text => text
-                .setPlaceholder('')
-                .setValue(this.plugin.settings.prjSettings.taskFolder)
-                .onChange(async (value) => {
-                    this.plugin.settings.prjSettings.taskFolder = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('')
+                    .setValue(this.plugin.settings.prjSettings.taskFolder)
+                    .onChange(async (value) => {
+                        this.plugin.settings.prjSettings.taskFolder = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Template file
         new Setting(containerEl)
             .setName('Template File')
             .setDesc('The Template file for new Tasks')
-            .addText(text => text
-                .setPlaceholder('')
-                .setValue(this.plugin.settings.prjSettings.taskTemplate)
-                .onChange(async (value) => {
-                    this.plugin.settings.prjSettings.taskTemplate = value;
-                    await this.plugin.saveSettings();
-                }));
+            .addText((text) =>
+                text
+                    .setPlaceholder('')
+                    .setValue(this.plugin.settings.prjSettings.taskTemplate)
+                    .onChange(async (value) => {
+                        this.plugin.settings.prjSettings.taskTemplate = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         // Sub Templates
         new Setting(containerEl)
             .setName('Sub Templates')
-            .setDesc('The Task Sub Templates. \nOne per line and Label and File separated by a semicolon.')
-            .addTextArea(text => text
-                .setPlaceholder('Sub Templates')
-                .setValue(this.plugin.settings.prjSettings.subTaskTemplates?.map((value) => `${value.label};${value.template}`).join('\n'))
-                .onChange(async (value) => {
-                    const lines = value.split('\n');
-                    this.plugin.settings.prjSettings.subTaskTemplates = lines.map((line) => {
-                        const parts = line.split(';');
-                        return {
-                            label: parts[0],
-                            template: parts[1]
-                        };
-                    });
-                    await this.plugin.saveSettings();
-                }));
+            .setDesc(
+                'The Task Sub Templates. \nOne per line and Label and File separated by a semicolon.',
+            )
+            .addTextArea((text) =>
+                text
+                    .setPlaceholder('Sub Templates')
+                    .setValue(
+                        this.plugin.settings.prjSettings.subTaskTemplates
+                            ?.map((value) => `${value.label};${value.template}`)
+                            .join('\n'),
+                    )
+                    .onChange(async (value) => {
+                        const lines = value.split('\n');
+
+                        this.plugin.settings.prjSettings.subTaskTemplates =
+                            lines.map((line) => {
+                                const parts = line.split(';');
+
+                                return {
+                                    label: parts[0],
+                                    template: parts[1],
+                                };
+                            });
+                        await this.plugin.saveSettings();
+                    }),
+            );
     }
 }

--- a/src/interfaces/ILogger.ts
+++ b/src/interfaces/ILogger.ts
@@ -5,7 +5,7 @@
 export interface ILogger {
     /**
      * Log a `trace` message.
-     * @param message The trace message to log. 
+     * @param message The trace message to log.
      * @param optionalParams Optional parameters: strings, objects, etc.
      */
     trace(message?: unknown, ...optionalParams: unknown[]): void;
@@ -37,5 +37,4 @@ export interface ILogger {
      * @param optionalParams Optional parameters: strings, objects, etc.
      */
     error(message?: unknown, ...optionalParams: unknown[]): void;
-
 }

--- a/src/interfaces/IPrjData.ts
+++ b/src/interfaces/IPrjData.ts
@@ -1,4 +1,3 @@
-
 export default interface IPrjData {
     tags: string[] | string | null | undefined;
 }

--- a/src/interfaces/IPrjDocument.ts
+++ b/src/interfaces/IPrjDocument.ts
@@ -1,4 +1,4 @@
-import { FileSubType, FileType } from "../types/PrjTypes";
+import { FileSubType, FileType } from '../types/PrjTypes';
 
 export default interface IPrjDocument {
     type: FileType | null | undefined;

--- a/src/interfaces/IPrjModel.ts
+++ b/src/interfaces/IPrjModel.ts
@@ -1,14 +1,14 @@
-import { TFile } from "obsidian";
+import { TFile } from 'obsidian';
 
 export default interface IPrjModel<T> {
-    get data(): Partial<T>
-    set data(value: Partial<T>)
+    get data(): Partial<T>;
+    set data(value: Partial<T>);
 
-    get file(): TFile
-    set file(value: TFile)
+    get file(): TFile;
+    set file(value: TFile);
 
-    get tags(): string[]
-    set tags(value: string[])
+    get tags(): string[];
+    set tags(value: string[]);
 
-    toString(): string
+    toString(): string;
 }

--- a/src/interfaces/IPrjTaskManagement.ts
+++ b/src/interfaces/IPrjTaskManagement.ts
@@ -1,4 +1,11 @@
-import { Energy, FileSubType, FileType, HistoryEntries, Priority, Status } from "../types/PrjTypes";
+import {
+    Energy,
+    FileSubType,
+    FileType,
+    HistoryEntries,
+    Priority,
+    Status,
+} from '../types/PrjTypes';
 
 export default interface IPrjTaskManagement {
     type: FileType | null | undefined;

--- a/src/interfaces/IProcessorSettings.ts
+++ b/src/interfaces/IProcessorSettings.ts
@@ -1,7 +1,11 @@
-import { Component, FrontMatterCache, MarkdownPostProcessorContext } from "obsidian";
-import { IProcessorOptions } from "src/interfaces/IProcessorOptions";
+import {
+    Component,
+    FrontMatterCache,
+    MarkdownPostProcessorContext,
+} from 'obsidian';
+import { IProcessorOptions } from 'src/interfaces/IProcessorOptions';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import MarkdownBlockProcessor from "src/libs/MarkdownBlockProcessor";
+import MarkdownBlockProcessor from 'src/libs/MarkdownBlockProcessor';
 
 /**
  * Interface for the processor settings.

--- a/src/libs/BlockRenderComponents/DocumentBlockRenderComponent.ts
+++ b/src/libs/BlockRenderComponents/DocumentBlockRenderComponent.ts
@@ -1,17 +1,19 @@
-import { DocumentModel } from "src/models/DocumentModel";
-import TableBlockRenderComponent, { BlockRenderSettings } from "./TableBlockRenderComponent";
-import { IProcessorSettings } from "../../interfaces/IProcessorSettings";
-import Search from "../Search";
-import Table, { Row, RowsState, TableHeader } from "../Table";
-import Lng from "src/classes/Lng";
-import FilterButton from "./InnerComponents/FilterButton";
-import MaxShownModelsInput from "./InnerComponents/MaxShownModelsInput";
-import SearchInput from "./InnerComponents/SearchInput";
-import Helper from "../Helper";
-import DocumentComponents from "./InnerComponents/DocumentComponents";
-import GeneralComponents from "./InnerComponents/GeneralComponents";
-import API from "src/classes/API";
-import { FileMetadata } from "../MetadataCache";
+import { DocumentModel } from 'src/models/DocumentModel';
+import TableBlockRenderComponent, {
+    BlockRenderSettings,
+} from './TableBlockRenderComponent';
+import { IProcessorSettings } from '../../interfaces/IProcessorSettings';
+import Search from '../Search';
+import Table, { Row, RowsState, TableHeader } from '../Table';
+import Lng from 'src/classes/Lng';
+import FilterButton from './InnerComponents/FilterButton';
+import MaxShownModelsInput from './InnerComponents/MaxShownModelsInput';
+import SearchInput from './InnerComponents/SearchInput';
+import Helper from '../Helper';
+import DocumentComponents from './InnerComponents/DocumentComponents';
+import GeneralComponents from './InnerComponents/GeneralComponents';
+import API from 'src/classes/API';
+import { FileMetadata } from '../MetadataCache';
 
 /**
  * Document block render component class for `TableBlockRenderComponent`.
@@ -23,27 +25,43 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
     protected settings: BlockRenderSettings = {
         tags: [],
         reactOnActiveFile: false,
-        filter: ["Documents"],
+        filter: ['Documents'],
         maxDocuments: this.global.settings.defaultMaxShow,
         search: undefined,
         searchText: undefined,
         batchSize: 8,
-        sleepBetweenBatches: 10
+        sleepBetweenBatches: 10,
     };
 
     /**
      * The table headers.
      * @remarks The table headers are used to create the table.
-     * 
+     *
      */
     protected tableHeaders: TableHeader[] = [
-        { text: Lng.gt("DocumentType"), headerClass: [], columnClass: ["dont-decorate-link", "font-medium"] },
-        { text: Lng.gt("Date"), headerClass: [], columnClass: ["font-xsmall"] },
-        { text: Lng.gt("Subject"), headerClass: [], columnClass: [] },
-        { text: Lng.gt("SendRecip"), headerClass: [], columnClass: ["font-xsmall"] },
-        { text: Lng.gt("Content description"), headerClass: [], columnClass: ["font-xsmall"] },
-        { text: Lng.gt("DeliveryDate"), headerClass: [], columnClass: ["font-xsmall"] },
-        { text: Lng.gt("Tags"), headerClass: [], columnClass: ["tags"] }
+        {
+            text: Lng.gt('DocumentType'),
+            headerClass: [],
+            columnClass: ['dont-decorate-link', 'font-medium'],
+        },
+        { text: Lng.gt('Date'), headerClass: [], columnClass: ['font-xsmall'] },
+        { text: Lng.gt('Subject'), headerClass: [], columnClass: [] },
+        {
+            text: Lng.gt('SendRecip'),
+            headerClass: [],
+            columnClass: ['font-xsmall'],
+        },
+        {
+            text: Lng.gt('Content description'),
+            headerClass: [],
+            columnClass: ['font-xsmall'],
+        },
+        {
+            text: Lng.gt('DeliveryDate'),
+            headerClass: [],
+            columnClass: ['font-xsmall'],
+        },
+        { text: Lng.gt('Tags'), headerClass: [], columnClass: ['tags'] },
     ];
 
     constructor(settings: IProcessorSettings) {
@@ -69,18 +87,22 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
         const documentsPromise = super.getModels(
             ['Metadata'],
             this.settings.tags,
-            (metadata: FileMetadata) => new DocumentModel(metadata.file));
+            (metadata: FileMetadata) => new DocumentModel(metadata.file),
+        );
         await super.draw();
         await this.buildTable();
         await this.buildHeader();
         this.grayOutHeader();
-        this.models = (await documentsPromise);
+        this.models = await documentsPromise;
 
         API.documentModel.sortDocumentsByDateDesc(this.models);
         await this.addDocumentsToTable();
         this.normalizeHeader();
         const endTime = Date.now();
-        this.logger.debug(`Redraw Documents (for ${this.models.length} Docs.) runs for ${endTime - startTime}ms`);
+
+        this.logger.debug(
+            `Redraw Documents (for ${this.models.length} Docs.) runs for ${endTime - startTime}ms`,
+        );
     }
 
     /**
@@ -105,43 +127,48 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
         const filterLabel = document.createElement('span');
         filterLabelContainer.appendChild(filterLabel);
         filterLabel.classList.add('filter-symbol');
-        filterLabel.textContent = Lng.gt("Filter");
+        filterLabel.textContent = Lng.gt('Filter');
 
         const documentFilterButton = FilterButton.create(
             this.component,
-            "Documents",
+            'Documents',
             this.globalSettings.documentSettings.symbol,
-            this.settings.filter.includes("Documents"),
-            this.onFilterButton.bind(this));
+            this.settings.filter.includes('Documents'),
+            this.onFilterButton.bind(this),
+        );
         headerFilterButtons.appendChild(documentFilterButton);
 
         const hideDocumentFilterButton = FilterButton.create(
             this.component,
-            "HideDocuments",
+            'HideDocuments',
             this.globalSettings.documentSettings.hideSymbol,
-            this.settings.filter.includes("HideDocuments"),
-            this.onFilterButton.bind(this));
+            this.settings.filter.includes('HideDocuments'),
+            this.onFilterButton.bind(this),
+        );
         headerFilterButtons.appendChild(hideDocumentFilterButton);
 
         const clusterFilterButton = FilterButton.create(
             this.component,
-            "Cluster",
+            'Cluster',
             this.globalSettings.documentSettings.clusterSymbol,
-            this.settings.filter.includes("Cluster"),
-            this.onFilterButton.bind(this));
+            this.settings.filter.includes('Cluster'),
+            this.onFilterButton.bind(this),
+        );
         headerFilterButtons.appendChild(clusterFilterButton);
 
         const maxDocuments = MaxShownModelsInput.create(
             this.component,
             this.settings.maxDocuments,
             this.global.settings.defaultMaxShow,
-            this.onMaxDocumentsChange.bind(this));
+            this.onMaxDocumentsChange.bind(this),
+        );
         headerFilterButtons.appendChild(maxDocuments);
 
         const searchBox = SearchInput.create(
             this.component,
             this.onSearch.bind(this),
-            this.settings.searchText);
+            this.settings.searchText,
+        );
         headerFilterButtons.appendChild(searchBox);
     }
 
@@ -153,7 +180,9 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
      */
     private async onFilterButton(type: string, status: boolean): Promise<void> {
         if (this.settings.filter.includes(type as FilteredDocument)) {
-            this.settings.filter = this.settings.filter.filter(v => v !== type);
+            this.settings.filter = this.settings.filter.filter(
+                (v) => v !== type,
+            );
         } else {
             this.settings.filter.push(type as FilteredDocument);
         }
@@ -162,6 +191,7 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
 
     private async onFilterDebounce(): Promise<void> {
         clearTimeout(this.filterButtonDebounceTimer);
+
         this.filterButtonDebounceTimer = setTimeout(async () => {
             await this.onFilter();
         }, 750);
@@ -173,9 +203,12 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
      * @returns A promise which is resolved when the documents are filtered.
      * @remarks Runs the `onFilter` method.
      */
-    private async onMaxDocumentsChange(maxDocuments: number): Promise<undefined> {
+    private async onMaxDocumentsChange(
+        maxDocuments: number,
+    ): Promise<undefined> {
         this.settings.maxDocuments = maxDocuments;
         this.onFilter();
+
         return undefined;
     }
 
@@ -189,8 +222,8 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
      * - After the search is applied, the `onFilter` method is called.
      */
     private async onSearch(search: string, key: string): Promise<string> {
-        if (key === "Enter") {
-            if (search !== "") {
+        if (key === 'Enter') {
+            if (search !== '') {
                 this.settings.searchText = search;
                 this.settings.search = Search.parseSearchText(search);
                 this.onFilter();
@@ -199,19 +232,21 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
                 this.settings.search = undefined;
                 this.onFilter();
             }
-        } else if (key === "Escape") {
+        } else if (key === 'Escape') {
             this.settings.searchText = undefined;
             this.settings.search = undefined;
             this.onFilter();
-            return "";
+
+            return '';
         }
+
         return search;
     }
 
     /**
      * Filters the documents and shows/hides them in the table.
      * @remarks - The documents are filtered by the `filter` setting,
-     * searched by the `search` setting 
+     * searched by the `search` setting
      * and the number of documents is limited by the `maxDocuments` if no search is applied.
      */
     private async onFilter() {
@@ -229,11 +264,18 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
             const rowUid = this.getUID(document);
             let hide = this.getHideState(document, undefined);
             this.logger.trace(`Document ${rowUid} is hidden by state: ${hide}`);
-            this.logger.trace(`Visible rows: ${visibleRows}; Max shown Docs: ${this.settings.maxDocuments}`);
+
+            this.logger.trace(
+                `Visible rows: ${visibleRows}; Max shown Docs: ${this.settings.maxDocuments}`,
+            );
+
             if (visibleRows >= this.settings.maxDocuments) {
-                hide = true
+                hide = true;
             }
-            this.logger.trace(`Document ${rowUid} is hidden by max counts: ${hide}`);
+
+            this.logger.trace(
+                `Document ${rowUid} is hidden by max counts: ${hide}`,
+            );
 
             if (hide) {
                 rows.push({ rowUid, hidden: true });
@@ -244,7 +286,10 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
 
             if ((i !== 0 && i % batchSize === 0) || i === documentsLength - 1) {
                 await sleepPromise;
-                this.logger.trace(`Batchsize reached. Change rows: ${rows.length}`);
+
+                this.logger.trace(
+                    `Batchsize reached. Change rows: ${rows.length}`,
+                );
                 await this.table.changeShowHideStateRows(rows);
                 rows.length = 0;
                 sleepPromise = Helper.sleep(sleepBetweenBatches);
@@ -263,7 +308,10 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
      * - The batch size is defined in the `batchSize` parameter. Default is `settings.batchSize`.
      * - The sleep time between the batches is defined in the `sleepBetweenBatches` parameter. Default is `settings.sleepBetweenBatches`.
      */
-    private async addDocumentsToTable(batchSize = this.settings.batchSize, sleepBetweenBatches = this.settings.sleepBetweenBatches): Promise<void> {
+    private async addDocumentsToTable(
+        batchSize = this.settings.batchSize,
+        sleepBetweenBatches = this.settings.sleepBetweenBatches,
+    ): Promise<void> {
         let sleepPromise = Promise.resolve();
         const documentsLength = this.models.length;
         const rows: Row[] = [];
@@ -278,7 +326,8 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
         let visibleRows = 0;
 
         for (let i = 0; i < documentsLength; i++) {
-            const document = i + 1 < documentsLength ? this.models[i + 1] : null;
+            const document =
+                i + 1 < documentsLength ? this.models[i + 1] : null;
 
             const row = await rowPromise;
             rowPromise = document ? this.generateTableRow(document) : undefined;
@@ -291,8 +340,7 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
                 }
             }
 
-            if (row)
-                rows.push(row);
+            if (row) rows.push(row);
 
             if ((i !== 0 && i % batchSize === 0) || i === documentsLength - 1) {
                 await sleepPromise;
@@ -316,69 +364,85 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
         // Row 0 -- Metadata Link
         const metadataLink = document.createDocumentFragment();
         rowData.push(metadataLink);
+
         DocumentComponents.createCellMetadatalink(
             metadataLink,
             this.component,
-            documentModel);
+            documentModel,
+        );
 
         // Row 1 -- Date
         const date = document.createDocumentFragment();
         rowData.push(date);
+
         GeneralComponents.createCellDate(
             date,
             this.component,
-            Lng.gt("DocumentDate"),
+            Lng.gt('DocumentDate'),
             this.global.settings.dateFormat,
-            () => documentModel.data.date ?? "na",
-            async (value: string) => documentModel.data.date = value);
+            () => documentModel.data.date ?? 'na',
+            async (value: string) => (documentModel.data.date = value),
+        );
 
         // Row 2 -- File Link
         const fileLink = document.createDocumentFragment();
         rowData.push(fileLink);
+
         DocumentComponents.createCellFileLink(
             fileLink,
             this.component,
-            documentModel);
+            documentModel,
+        );
 
         // Row 3 -- Sender Recipient
         const senderRecipient = DocumentComponents.createCellSenderRecipient(
             documentModel,
             this.component,
-            this.models);
+            this.models,
+        );
         rowData.push(senderRecipient);
 
         // Row 4 -- Summary & Related Files
         const summaryRelatedFiles = document.createDocumentFragment();
         rowData.push(summaryRelatedFiles);
+
         DocumentComponents.createCellSummary(
             documentModel,
             this.component,
-            summaryRelatedFiles);
+            summaryRelatedFiles,
+        );
+
         DocumentComponents.createRelatedFilesList(
             summaryRelatedFiles,
             this.component,
             documentModel,
             this.globalSettings.noneSymbol,
-            this.global.settings.dateFormatShort);
+            this.global.settings.dateFormatShort,
+        );
 
         // Row 5 -- Date of delivery
         const deliveryDate = document.createDocumentFragment();
         rowData.push(deliveryDate);
+
         GeneralComponents.createCellDate(
             deliveryDate,
             this.component,
-            Lng.gt("DeliveryDate"),
+            Lng.gt('DeliveryDate'),
             this.global.settings.dateFormat,
-            () => documentModel.data.dateOfDelivery ?? "na",
-            async (value: string) => documentModel.data.dateOfDelivery = value);
+            () => documentModel.data.dateOfDelivery ?? 'na',
+            async (value: string) =>
+                (documentModel.data.dateOfDelivery = value),
+        );
 
         // Row 6 -- Tags
         const tags = document.createDocumentFragment();
         rowData.push(tags);
+
         GeneralComponents.createCellTags(
             tags,
             this.component,
-            documentModel.getTags());
+            documentModel.getTags(),
+        );
 
         const hide = this.getHideState(documentModel, undefined);
 
@@ -386,12 +450,16 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
             rowUid,
             rowData,
             rowClassList,
-            hidden: hide
+            hidden: hide,
         };
+
         return row;
     }
 
-    private getHideState(document: DocumentModel, maxVisibleRows: number | undefined): boolean {
+    private getHideState(
+        document: DocumentModel,
+        maxVisibleRows: number | undefined,
+    ): boolean {
         let searchResult = false;
         let maxRows = false;
 
@@ -405,7 +473,9 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
             maxRows = rowStats.visibleRows >= maxVisibleRows;
         }
 
-        const hide = this.determineHideState(document) || this.determineTagHideState(document);
+        const hide =
+            this.determineHideState(document) ||
+            this.determineTagHideState(document);
 
         if (searchResult && !hide) {
             return false; // Shows the document, if it is not hidden and the search was successful
@@ -425,20 +495,35 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
      * @remarks - The document is hidden if the `filter` setting not includes the document type.
      */
     private determineHideState(document: DocumentModel): boolean {
-        if (this.settings.filter.includes("Documents") && document.data.hide !== true && document.data.subType !== "Cluster") {
+        if (
+            this.settings.filter.includes('Documents') &&
+            document.data.hide !== true &&
+            document.data.subType !== 'Cluster'
+        ) {
             return false;
         }
-        if (this.settings.filter.includes("Cluster") && document.data.subType === "Cluster") {
+
+        if (
+            this.settings.filter.includes('Cluster') &&
+            document.data.subType === 'Cluster'
+        ) {
             return false;
         }
-        if (this.settings.filter.includes("HideDocuments") && document.data.hide === true) {
+
+        if (
+            this.settings.filter.includes('HideDocuments') &&
+            document.data.hide === true
+        ) {
             return false;
         }
+
         return true;
     }
 
     private determineTagHideState(document: DocumentModel): boolean {
-        return this.settings.reactOnActiveFile ? !Helper.isTagIncluded(this.settings.tags, document.getTags()) : false;
+        return this.settings.reactOnActiveFile
+            ? !Helper.isTagIncluded(this.settings.tags, document.getTags())
+            : false;
     }
 
     public onActiveFileFilter() {
@@ -453,14 +538,13 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
      * - The table has the headers from the `tableHeaders` property.
      */
     private async buildTable(): Promise<void> {
-        this.table = new Table(this.tableHeaders, "document-table", undefined);
+        this.table = new Table(this.tableHeaders, 'document-table', undefined);
         this.tableContainer.appendChild(this.table.data.table);
     }
 
     public redraw(): Promise<void> {
         return super.redraw();
     }
-
 }
 
 /**
@@ -469,4 +553,4 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
  * - `HideDocuments` - Show hidden documents.
  * - `Cluster` - Show clusters.
  */
-type FilteredDocument = "Documents" | "HideDocuments" | "Cluster";
+type FilteredDocument = 'Documents' | 'HideDocuments' | 'Cluster';

--- a/src/libs/BlockRenderComponents/HeaderBlockRenderComponent.ts
+++ b/src/libs/BlockRenderComponents/HeaderBlockRenderComponent.ts
@@ -1,11 +1,11 @@
-import { FrontMatterCache, MarkdownRenderer, TFile } from "obsidian";
-import Global from "src/classes/Global";
-import Lng from "src/classes/Lng";
-import { IProcessorSettings } from "src/interfaces/IProcessorSettings";
-import Tags, { TagTree } from "../Tags";
-import Logging from "src/classes/Logging";
-import RedrawableBlockRenderComponent from "./RedrawableBlockRenderComponent";
-import CustomizableRenderChild from "../CustomizableRenderChild";
+import { FrontMatterCache, MarkdownRenderer, TFile } from 'obsidian';
+import Global from 'src/classes/Global';
+import Lng from 'src/classes/Lng';
+import { IProcessorSettings } from 'src/interfaces/IProcessorSettings';
+import Tags, { TagTree } from '../Tags';
+import Logging from 'src/classes/Logging';
+import RedrawableBlockRenderComponent from './RedrawableBlockRenderComponent';
+import CustomizableRenderChild from '../CustomizableRenderChild';
 
 /**
  * Header Block Render Component class.
@@ -17,10 +17,12 @@ import CustomizableRenderChild from "../CustomizableRenderChild";
  * @remarks This header watches the `prj-task-management-file-changed` event
  * and redraws the header when the event is fired and the file is the file in which the block is located.
  */
-export default class HeaderBlockRenderComponent implements RedrawableBlockRenderComponent {
+export default class HeaderBlockRenderComponent
+    implements RedrawableBlockRenderComponent
+{
     private app = Global.getInstance().app;
     private global = Global.getInstance();
-    private logger = Logging.getLogger("HeaderBlockRenderComponent");
+    private logger = Logging.getLogger('HeaderBlockRenderComponent');
     private metadataCache = this.global.metadataCache;
 
     private _processorSettings: IProcessorSettings;
@@ -38,7 +40,7 @@ export default class HeaderBlockRenderComponent implements RedrawableBlockRender
 
     /**
      * Sets the path value.
-     * 
+     *
      * @param value - The new path value.
      */
     private set path(value: string) {
@@ -62,6 +64,7 @@ export default class HeaderBlockRenderComponent implements RedrawableBlockRender
             this._headerContainer = document.createElement('div');
             this._headerContainer.addClass('header-block-component');
         }
+
         return this._headerContainer;
     }
 
@@ -94,7 +97,10 @@ export default class HeaderBlockRenderComponent implements RedrawableBlockRender
      * The frontmatter of the Prj File.
      */
     private get frontmatter(): FrontMatterCache | undefined {
-        return this.metadataCache.getEntryByPath(this.path)?.metadata?.frontmatter ?? undefined;
+        return (
+            this.metadataCache.getEntryByPath(this.path)?.metadata
+                ?.frontmatter ?? undefined
+        );
     }
 
     /**
@@ -108,12 +114,16 @@ export default class HeaderBlockRenderComponent implements RedrawableBlockRender
         this._processorSettings = settings;
         this.onUnload = this.onUnload.bind(this);
         this.redraw = this.redraw.bind(this);
-        this.onDocumentChangedMetadata = this.onDocumentChangedMetadata.bind(this);
+
+        this.onDocumentChangedMetadata =
+            this.onDocumentChangedMetadata.bind(this);
+
         this.childComponent = new CustomizableRenderChild(
             this.container,
             () => this.onLoad(),
             () => this.onUnload(),
-            this.logger);
+            this.logger,
+        );
         this.childComponent.load();
         this._processorSettings.ctx.addChild(this.childComponent);
         this.parseSettings();
@@ -124,7 +134,10 @@ export default class HeaderBlockRenderComponent implements RedrawableBlockRender
      * @remarks This function is called when the block is loaded and register the `prj-task-management-file-changed` event.
      */
     private onLoad(): void {
-        this.metadataCache.on('prj-task-management-file-changed', this.onDocumentChangedMetadata);
+        this.metadataCache.on(
+            'prj-task-management-file-changed',
+            this.onDocumentChangedMetadata,
+        );
     }
 
     /**
@@ -132,7 +145,10 @@ export default class HeaderBlockRenderComponent implements RedrawableBlockRender
      * @remarks This function is called when the block is unloaded and unregister the `prj-task-management-file-changed` event.
      */
     private onUnload(): void {
-        this.metadataCache.off('prj-task-management-file-changed', this.onDocumentChangedMetadata);
+        this.metadataCache.off(
+            'prj-task-management-file-changed',
+            this.onDocumentChangedMetadata,
+        );
     }
 
     /**
@@ -145,7 +161,9 @@ export default class HeaderBlockRenderComponent implements RedrawableBlockRender
             this.headerContainer?.empty();
             await this.build();
         } catch (error) {
-            this.logger.error(`Error while redrawing HeaderBlockRenderComponent: ${error}`);
+            this.logger.error(
+                `Error while redrawing HeaderBlockRenderComponent: ${error}`,
+            );
         }
     }
 
@@ -166,18 +184,21 @@ export default class HeaderBlockRenderComponent implements RedrawableBlockRender
      */
     public async build(): Promise<void> {
         try {
-            if (this.title)
-                this.headerContainer.append(this.createTitle());
-            if (this.status)
-                this.headerContainer.append(this.createStatus());
+            if (this.title) this.headerContainer.append(this.createTitle());
+
+            if (this.status) this.headerContainer.append(this.createStatus());
+
             if (this.tags.length > 0)
                 this.headerContainer.append(this.createTags());
+
             if (this.description)
                 this.headerContainer.append(this.createDescription());
 
             this.container.append(this.headerContainer);
         } catch (error) {
-            this.logger.error(`Error while building HeaderBlockRenderComponent: ${error}`);
+            this.logger.error(
+                `Error while building HeaderBlockRenderComponent: ${error}`,
+            );
         }
     }
 
@@ -189,7 +210,13 @@ export default class HeaderBlockRenderComponent implements RedrawableBlockRender
         const titleDiv = document.createElement('div');
         titleDiv.classList.add('title');
 
-        MarkdownRenderer.render(this.app, `# ${this.title}`, titleDiv, this.path, this.component);
+        MarkdownRenderer.render(
+            this.app,
+            `# ${this.title}`,
+            titleDiv,
+            this.path,
+            this.component,
+        );
 
         return this.createDocumentFragment(titleDiv);
     }
@@ -202,7 +229,13 @@ export default class HeaderBlockRenderComponent implements RedrawableBlockRender
         const statusDiv = document.createElement('div');
         statusDiv.classList.add('status');
 
-        MarkdownRenderer.render(this.app, `${Lng.gt("Status")}: **${this.status}**`, statusDiv, this.path, this.component);
+        MarkdownRenderer.render(
+            this.app,
+            `${Lng.gt('Status')}: **${this.status}**`,
+            statusDiv,
+            this.path,
+            this.component,
+        );
 
         return this.createDocumentFragment(statusDiv);
     }
@@ -215,7 +248,13 @@ export default class HeaderBlockRenderComponent implements RedrawableBlockRender
         const descriptionDiv = document.createElement('div');
         descriptionDiv.classList.add('description');
 
-        MarkdownRenderer.render(this.app, `${this.description}`, descriptionDiv, this.path, this.component);
+        MarkdownRenderer.render(
+            this.app,
+            `${this.description}`,
+            descriptionDiv,
+            this.path,
+            this.component,
+        );
 
         return this.createDocumentFragment(descriptionDiv);
     }
@@ -232,7 +271,11 @@ export default class HeaderBlockRenderComponent implements RedrawableBlockRender
         for (const tag in tagTree) {
             const fullPath = path ? `${path}/${tag}` : tag;
             const li = document.createElement('li');
-            const tagLink = Tags.createObsidianTagLink(path ? tag : `#${tag}`, fullPath);
+
+            const tagLink = Tags.createObsidianTagLink(
+                path ? tag : `#${tag}`,
+                fullPath,
+            );
             li.appendChild(tagLink);
             const subTags = tagTree[tag];
             const hasSubTags = Object.keys(subTags).length > 0;
@@ -258,7 +301,7 @@ export default class HeaderBlockRenderComponent implements RedrawableBlockRender
         const labelDiv = document.createElement('div');
         tagsDiv.appendChild(labelDiv);
         labelDiv.classList.add('tag-label');
-        labelDiv.textContent = `${Lng.gt("Tags")}:`;
+        labelDiv.textContent = `${Lng.gt('Tags')}:`;
 
         const tagTree = Tags.createTagTree(this.tags);
         const tagsList = this.createDomList(tagTree);
@@ -275,6 +318,7 @@ export default class HeaderBlockRenderComponent implements RedrawableBlockRender
     private createDocumentFragment(element: HTMLElement): DocumentFragment {
         const documentFragment = new DocumentFragment();
         documentFragment.append(element);
+
         return documentFragment;
     }
 
@@ -283,14 +327,22 @@ export default class HeaderBlockRenderComponent implements RedrawableBlockRender
      * @remarks This function is called in the constructor.
      */
     private parseSettings(): void {
-        if (!this._processorSettings.options || this._processorSettings.options.length === 0) return;
-        this._processorSettings.options.forEach(option => {
+        if (
+            !this._processorSettings.options ||
+            this._processorSettings.options.length === 0
+        )
+            return;
+
+        this._processorSettings.options.forEach((option) => {
             switch (option.label) {
-                case "watchActiveFile":
-                    if (option.value === "true") {
+                case 'watchActiveFile':
+                    if (option.value === 'true') {
                         // Register event to update the header when the active file changes
                         this.component.registerEvent(
-                            this.global.app.workspace.on('active-leaf-change', () => this.onActiveFileChange.bind(this)())
+                            this.global.app.workspace.on(
+                                'active-leaf-change',
+                                () => this.onActiveFileChange.bind(this)(),
+                            ),
                         );
                     }
                     break;
@@ -308,8 +360,10 @@ export default class HeaderBlockRenderComponent implements RedrawableBlockRender
      */
     private onActiveFileChange(): void {
         const activeFile = this.global.app.workspace.getActiveFile();
-        if (activeFile && !activeFile.path.contains("Ressourcen/Panels/")) {
-            this.logger.trace("Active file changed: ", activeFile.path);
+
+        if (activeFile && !activeFile.path.contains('Ressourcen/Panels/')) {
+            this.logger.trace('Active file changed: ', activeFile.path);
+
             if (this.path !== activeFile.path) {
                 this.path = activeFile.path;
                 this.onActiveFileDebounce();
@@ -321,11 +375,11 @@ export default class HeaderBlockRenderComponent implements RedrawableBlockRender
      * Debounces the active file change event and triggers a redraw after a delay.
      */
     private onActiveFileDebounce(): void {
-        this.logger.trace("Active file changed: Debouncing");
+        this.logger.trace('Active file changed: Debouncing');
         clearTimeout(this.activeFileDebounceTimer);
+
         this.activeFileDebounceTimer = setTimeout(async () => {
             this.redraw();
         }, 750);
     }
-
 }

--- a/src/libs/BlockRenderComponents/InnerComponents/DocumentComponents.ts
+++ b/src/libs/BlockRenderComponents/InnerComponents/DocumentComponents.ts
@@ -1,28 +1,32 @@
-import { Component, MarkdownRenderer, TFile, setIcon } from "obsidian";
-import Global from "src/classes/Global";
-import Lng from "src/classes/Lng";
-import EditableDataView from "src/libs/EditableDataView/EditableDataView";
-import Helper from "src/libs/Helper";
-import { DocumentModel } from "src/models/DocumentModel";
-import { StaticDocumentModel } from "src/models/StaticHelper/StaticDocumentModel";
+import { Component, MarkdownRenderer, TFile, setIcon } from 'obsidian';
+import Global from 'src/classes/Global';
+import Lng from 'src/classes/Lng';
+import EditableDataView from 'src/libs/EditableDataView/EditableDataView';
+import Helper from 'src/libs/Helper';
+import { DocumentModel } from 'src/models/DocumentModel';
+import { StaticDocumentModel } from 'src/models/StaticHelper/StaticDocumentModel';
 
 export default class DocumentComponents {
     public static createCellSummary(
         documentModel: DocumentModel,
         component: Component,
-        summaryRelatedFiles: DocumentFragment) {
-        const description = documentModel.data.description ?? "";
-        new EditableDataView(summaryRelatedFiles, component)
-            .addTextarea(textarea => textarea
-                .setValue(description)
-                .setTitle("Summary")
-                .enableEditability()
-                .setRenderMarkdown()
-                .onSave((value: string) => {
-                    documentModel.data.description = value;
-                    return Promise.resolve();
-                })
-            );
+        summaryRelatedFiles: DocumentFragment,
+    ) {
+        const description = documentModel.data.description ?? '';
+
+        new EditableDataView(summaryRelatedFiles, component).addTextarea(
+            (textarea) =>
+                textarea
+                    .setValue(description)
+                    .setTitle('Summary')
+                    .enableEditability()
+                    .setRenderMarkdown()
+                    .onSave((value: string) => {
+                        documentModel.data.description = value;
+
+                        return Promise.resolve();
+                    }),
+        );
     }
 
     public static createRelatedFilesList(
@@ -30,8 +34,10 @@ export default class DocumentComponents {
         component: Component,
         documentModel: DocumentModel,
         noneDocSymbol: string,
-        dateFormatShort: string) {
+        dateFormatShort: string,
+    ) {
         const relatedFiles = documentModel.relatedFiles;
+
         if (!relatedFiles || relatedFiles.length === 0) return;
         const container = document.createElement('div');
         relatedFilesList.appendChild(container);
@@ -45,7 +51,7 @@ export default class DocumentComponents {
         container.appendChild(list);
         list.classList.add('related-files-list');
 
-        relatedFiles.forEach(relatedFile => {
+        relatedFiles.forEach((relatedFile) => {
             const listEntry = document.createElement('li');
             list.append(listEntry);
 
@@ -54,43 +60,61 @@ export default class DocumentComponents {
             gridContainer.classList.add('grid-container');
 
             const iconContainer = document.createElement('span');
-            gridContainer.append(iconContainer)
+            gridContainer.append(iconContainer);
             iconContainer.classList.add('icon-container');
             const inputOutputState = relatedFile.getInputOutputState();
             //Input, Output or default icon
             let listIconString = noneDocSymbol;
-            if (inputOutputState === "Input") {
-                listIconString = "corner-left-down";
-            } else if (inputOutputState === "Output") {
-                listIconString = "corner-right-up";
+
+            if (inputOutputState === 'Input') {
+                listIconString = 'corner-left-down';
+            } else if (inputOutputState === 'Output') {
+                listIconString = 'corner-right-up';
             }
             setIcon(iconContainer, listIconString);
 
             //Metadata File Link
             const metadataContainer = document.createElement('span');
-            gridContainer.append(metadataContainer)
+            gridContainer.append(metadataContainer);
             metadataContainer.classList.add('metadata-file-container');
             const metadataFragment = document.createDocumentFragment();
-            this.createCellMetadatalink(metadataFragment, component, relatedFile);
+
+            this.createCellMetadatalink(
+                metadataFragment,
+                component,
+                relatedFile,
+            );
             metadataContainer.appendChild(metadataFragment);
 
             //Date
             const dateContainer = document.createElement('span');
-            gridContainer.append(dateContainer)
+            gridContainer.append(dateContainer);
             dateContainer.classList.add('date-container');
-            new EditableDataView(dateContainer, component)
-                .addDate(date => date
-                    .setValue(relatedFile.data.date ?? "na")
-                    .setTitle("Document Date")
-                    .setFormator((value: string) => Helper.formatDate(value, Helper.formatDate(value, dateFormatShort))
-                    ));
+
+            new EditableDataView(dateContainer, component).addDate((date) =>
+                date
+                    .setValue(relatedFile.data.date ?? 'na')
+                    .setTitle('Document Date')
+                    .setFormator((value: string) =>
+                        Helper.formatDate(
+                            value,
+                            Helper.formatDate(value, dateFormatShort),
+                        ),
+                    ),
+            );
 
             const textContainer = document.createElement('span');
-            gridContainer.append(textContainer)
+            gridContainer.append(textContainer);
             textContainer.classList.add('data-container');
             const linkFragment = document.createDocumentFragment();
+
             //Title and Link
-            this.createCellFileLink(linkFragment, component, relatedFile, false);
+            this.createCellFileLink(
+                linkFragment,
+                component,
+                relatedFile,
+                false,
+            );
             textContainer.append(linkFragment);
         });
     }
@@ -98,7 +122,8 @@ export default class DocumentComponents {
     public static createCellSenderRecipient(
         documentModel: DocumentModel,
         component: Component,
-        models: DocumentModel[]): DocumentFragment {
+        models: DocumentModel[],
+    ): DocumentFragment {
         const senderRecipient = document.createDocumentFragment();
         const container = document.createElement('div');
         senderRecipient.appendChild(container);
@@ -108,44 +133,64 @@ export default class DocumentComponents {
         const sender = documentModel.data.sender ?? null;
         const recipient = documentModel.data.recipient ?? null;
 
-        if (sender && inputOutputState !== "Output") {
+        if (sender && inputOutputState !== 'Output') {
             const senderContainer = document.createElement('div');
             senderContainer.classList.add('container');
 
             const fromTo = document.createElement('span');
             fromTo.classList.add('fromTo');
-            fromTo.textContent = Lng.gt("From");
+            fromTo.textContent = Lng.gt('From');
             senderContainer.appendChild(fromTo);
 
             const name = document.createElement('span');
             name.classList.add('name');
             senderContainer.appendChild(name);
-            this.createEDVSenderRecipient(name, component, sender, "Sender", (value: string) => {
-                documentModel.data.sender = value;
-                return Promise.resolve();
-            }, models);
+
+            this.createEDVSenderRecipient(
+                name,
+                component,
+                sender,
+                'Sender',
+                (value: string) => {
+                    documentModel.data.sender = value;
+
+                    return Promise.resolve();
+                },
+                models,
+            );
 
             container.appendChild(senderContainer);
         }
-        if (recipient && inputOutputState !== "Input") {
+
+        if (recipient && inputOutputState !== 'Input') {
             const recipientContainer = document.createElement('div');
             recipientContainer.classList.add('container');
 
             const fromTo = document.createElement('span');
             fromTo.classList.add('fromTo');
-            fromTo.textContent = Lng.gt("To");
+            fromTo.textContent = Lng.gt('To');
             recipientContainer.appendChild(fromTo);
 
             const name = document.createElement('span');
             name.classList.add('name');
             recipientContainer.appendChild(name);
-            this.createEDVSenderRecipient(name, component, recipient, "Recipient", (value: string) => {
-                documentModel.data.recipient = value;
-                return Promise.resolve();
-            }, models);
+
+            this.createEDVSenderRecipient(
+                name,
+                component,
+                recipient,
+                'Recipient',
+                (value: string) => {
+                    documentModel.data.recipient = value;
+
+                    return Promise.resolve();
+                },
+                models,
+            );
 
             container.appendChild(recipientContainer);
         }
+
         return senderRecipient;
     }
 
@@ -155,86 +200,122 @@ export default class DocumentComponents {
         value: string,
         title: string,
         onSaveCallback: (value: string) => Promise<void>,
-        models: DocumentModel[] = []) {
-        return new EditableDataView(name, component)
-            .addText(text => text
+        models: DocumentModel[] = [],
+    ) {
+        return new EditableDataView(name, component).addText((text) =>
+            text
                 .setValue(value)
                 .setTitle(title)
                 .enableEditability()
                 .setSuggester((inputValue: string) => {
-                    const suggestions = StaticDocumentModel.getAllSenderRecipients()
-                        .filter(suggestion => suggestion.toLowerCase().includes(inputValue.toLowerCase()))
-                        .slice(0, 100)
-                        .map(suggestion => { return { value: suggestion, label: suggestion } });
+                    const suggestions =
+                        StaticDocumentModel.getAllSenderRecipients()
+                            .filter((suggestion) =>
+                                suggestion
+                                    .toLowerCase()
+                                    .includes(inputValue.toLowerCase()),
+                            )
+                            .slice(0, 100)
+                            .map((suggestion) => {
+                                return { value: suggestion, label: suggestion };
+                            });
+
                     return suggestions;
                 })
-                .onSave((newValue: string) => onSaveCallback(newValue))
-            );
+                .onSave((newValue: string) => onSaveCallback(newValue)),
+        );
     }
 
     public static createCellFileLink(
         fileLink: DocumentFragment,
         component: Component,
         documentModel: DocumentModel,
-        editability = true) {
+        editability = true,
+    ) {
         const fileCache = Global.getInstance().fileCache;
         const app = Global.getInstance().app;
-        new EditableDataView(fileLink, component)
-            .addLink(link => {
-                link.setValue(documentModel.data.title ?? "")
-                    .setTitle(Lng.gt("PDF file"))
-                    .setLinkType("file")
-                    .setFormator((value: string) => {
-                        const baseFileData = Helper.extractDataFromWikilink(documentModel.data.file);
-                        const baseFile = fileCache.findFileByLinkText(baseFileData.filename ?? "", documentModel.file.path);
-                        let baseFilePath = baseFileData.filename ?? "";
-                        if (baseFile && baseFile instanceof TFile) {
-                            baseFilePath = baseFile.path;
-                        }
-                        let docFragment: DocumentFragment | undefined = undefined;
-                        if (Helper.isPossiblyMarkdown(value)) {
-                            docFragment = document.createDocumentFragment();
-                            const div = document.createElement('div');
-                            MarkdownRenderer.render(app, value ?? "", div, "", component);
-                            docFragment.appendChild(div);
-                        }
-                        return { href: `${baseFilePath}`, text: `${value}`, html: docFragment };
-                    });
-                if (editability) {
-                    link.enableEditability()
-                        .onSave((value: string) => {
-                            documentModel.data.title = value;
-                            return Promise.resolve();
-                        });
-                }
-            });
+
+        new EditableDataView(fileLink, component).addLink((link) => {
+            link.setValue(documentModel.data.title ?? '')
+                .setTitle(Lng.gt('PDF file'))
+                .setLinkType('file')
+                .setFormator((value: string) => {
+                    const baseFileData = Helper.extractDataFromWikilink(
+                        documentModel.data.file,
+                    );
+
+                    const baseFile = fileCache.findFileByLinkText(
+                        baseFileData.filename ?? '',
+                        documentModel.file.path,
+                    );
+                    let baseFilePath = baseFileData.filename ?? '';
+
+                    if (baseFile && baseFile instanceof TFile) {
+                        baseFilePath = baseFile.path;
+                    }
+                    let docFragment: DocumentFragment | undefined = undefined;
+
+                    if (Helper.isPossiblyMarkdown(value)) {
+                        docFragment = document.createDocumentFragment();
+                        const div = document.createElement('div');
+
+                        MarkdownRenderer.render(
+                            app,
+                            value ?? '',
+                            div,
+                            '',
+                            component,
+                        );
+                        docFragment.appendChild(div);
+                    }
+
+                    return {
+                        href: `${baseFilePath}`,
+                        text: `${value}`,
+                        html: docFragment,
+                    };
+                });
+
+            if (editability) {
+                link.enableEditability().onSave((value: string) => {
+                    documentModel.data.title = value;
+
+                    return Promise.resolve();
+                });
+            }
+        });
     }
 
     public static createCellMetadatalink(
         metadataLink: DocumentFragment,
         component: Component,
-        documentModel: DocumentModel) {
+        documentModel: DocumentModel,
+    ) {
         const settings = Global.getInstance().settings;
-        new EditableDataView(metadataLink, component)
-            .addLink(link => link
+
+        new EditableDataView(metadataLink, component).addLink((link) =>
+            link
                 .setValue(documentModel.file.path)
-                .setTitle("Open metadata file")
-                .setLinkType("file")
+                .setTitle('Open metadata file')
+                .setLinkType('file')
                 .setFormator((value: string) => {
                     const icon = document.createDocumentFragment();
-                    let iconString = "x-circle";
+                    let iconString = 'x-circle';
+
                     if (documentModel.data.hide === true) {
                         iconString = settings.documentSettings.hideSymbol;
                     } else {
-                        if (documentModel.data.subType === "Cluster") {
-                            iconString = settings.documentSettings.clusterSymbol;
+                        if (documentModel.data.subType === 'Cluster') {
+                            iconString =
+                                settings.documentSettings.clusterSymbol;
                         } else {
                             iconString = settings.documentSettings.symbol;
                         }
                     }
                     setIcon(icon as unknown as HTMLDivElement, iconString);
+
                     return { href: `${value}`, text: `${value}`, html: icon };
-                }
-                ));
+                }),
+        );
     }
 }

--- a/src/libs/BlockRenderComponents/InnerComponents/FilterButton.ts
+++ b/src/libs/BlockRenderComponents/InnerComponents/FilterButton.ts
@@ -1,18 +1,17 @@
-import { Component, setIcon } from "obsidian";
-import Global from "src/classes/Global";
-import Lng from "src/classes/Lng";
+import { Component, setIcon } from 'obsidian';
+import Global from 'src/classes/Global';
+import Lng from 'src/classes/Lng';
 
 /**
  * Max shown models input component class for `TableBlockRenderComponent`.
- * 
+ *
  * This class provides methods to create and manage a filter button component with a symbol.
  * It includes functionality for toggling the filter button and handling click events.
- * 
+ *
  * @see {@link create} for details about creating a filter button component.
  * @see {@link FilterCallback} for details about the filter callback.
  */
 export default class FilterButton {
-
     /**
      * Creates a new filter button.
      * @param component The component to register the events to.
@@ -31,13 +30,20 @@ export default class FilterButton {
         type: string,
         symbol: string,
         status: boolean,
-        onFilter: FilterCallback): DocumentFragment {
+        onFilter: FilterCallback,
+    ): DocumentFragment {
         const headerItemContainer = document.createDocumentFragment();
 
         const filterButtonContainer = document.createElement('div');
         headerItemContainer.appendChild(filterButtonContainer);
 
-        const filter = FilterButton.createFilterButton(status, type, symbol, component, onFilter);
+        const filter = FilterButton.createFilterButton(
+            status,
+            type,
+            symbol,
+            component,
+            onFilter,
+        );
         filterButtonContainer.appendChild(filter);
 
         return headerItemContainer;
@@ -61,28 +67,41 @@ export default class FilterButton {
         type: string,
         symbol: string,
         component: Component,
-        filterCallback: FilterCallback): DocumentFragment {
+        filterCallback: FilterCallback,
+    ): DocumentFragment {
         const logger = Global.getInstance().logger;
         const filterButtonContainer = document.createDocumentFragment();
 
         const filter = document.createElement('a');
         filterButtonContainer.appendChild(filter);
         filter.classList.add('filter-symbol');
+
         if (!status) {
             filter.classList.add('filter-symbol-hide');
         }
         filter.title = Lng.gt(type);
-        filter.href = "#";
+        filter.href = '#';
         setIcon(filter, symbol);
 
-        component.registerDomEvent(filter, 'click', async (event: MouseEvent) => {
-            filter.classList.toggle('filter-symbol-hide');
-            try {
-                await filterCallback(type, filter.classList.contains('filter-symbol-hide'));
-            } catch (error) {
-                logger.error("The `onFilter` callback threw an error!", error);
-            }
-        });
+        component.registerDomEvent(
+            filter,
+            'click',
+            async (event: MouseEvent) => {
+                filter.classList.toggle('filter-symbol-hide');
+
+                try {
+                    await filterCallback(
+                        type,
+                        filter.classList.contains('filter-symbol-hide'),
+                    );
+                } catch (error) {
+                    logger.error(
+                        'The `onFilter` callback threw an error!',
+                        error,
+                    );
+                }
+            },
+        );
 
         return filterButtonContainer;
     }

--- a/src/libs/BlockRenderComponents/InnerComponents/GeneralComponents.ts
+++ b/src/libs/BlockRenderComponents/InnerComponents/GeneralComponents.ts
@@ -1,12 +1,11 @@
-import { Component, setIcon } from "obsidian";
-import Global from "src/classes/Global";
-import Lng from "src/classes/Lng";
-import EditableDataView from "src/libs/EditableDataView/EditableDataView";
-import Helper from "src/libs/Helper";
-import { FileType } from "src/types/PrjTypes";
+import { Component, setIcon } from 'obsidian';
+import Global from 'src/classes/Global';
+import Lng from 'src/classes/Lng';
+import EditableDataView from 'src/libs/EditableDataView/EditableDataView';
+import Helper from 'src/libs/Helper';
+import { FileType } from 'src/types/PrjTypes';
 
 export default class GeneralComponents {
-
     /**
      * Creates a link to the file at `path` with the `corospondingSymbol` as icon.
      * @param container The container to append the link to.
@@ -20,19 +19,21 @@ export default class GeneralComponents {
         component: Component,
         path: string,
         type: FileType | undefined | null,
-        corospondingSymbol: string) {
-        new EditableDataView(container, component)
-            .addLink(link => link
+        corospondingSymbol: string,
+    ) {
+        new EditableDataView(container, component).addLink((link) =>
+            link
                 .setValue(path)
-                .setTitle(Lng.gt(type ?? "File"))
-                .setLinkType("file")
+                .setTitle(Lng.gt(type ?? 'File'))
+                .setLinkType('file')
                 .setFormator((value: string) => {
                     const icon = document.createDocumentFragment();
                     const iconString = corospondingSymbol;
                     setIcon(icon as unknown as HTMLDivElement, iconString);
+
                     return { href: `${value}`, text: `${value}`, html: icon };
-                }
-                ));
+                }),
+        );
     }
 
     public static createCellDate(
@@ -41,40 +42,53 @@ export default class GeneralComponents {
         title: string,
         format: string,
         onRead: () => string,
-        onWrite: (value: string) => void) {
-        new EditableDataView(date, component)
-            .addDate(date => date
+        onWrite: (value: string) => void,
+    ) {
+        new EditableDataView(date, component).addDate((date) =>
+            date
                 .setValue(onRead())
                 .setTitle(title)
                 .enableEditability()
-                .setFormator((value: string) => Helper.formatDate(value, format))
+                .setFormator((value: string) =>
+                    Helper.formatDate(value, format),
+                )
                 .onSave((value: string) => {
                     onWrite(value);
+
                     return Promise.resolve();
-                })
-            );
+                }),
+        );
     }
 
     public static createCellTags(
         tagContainer: DocumentFragment,
         component: Component,
-        tags: string[]) {
-        tags.forEach(tag => {
-            new EditableDataView(tagContainer, component)
-                .addLink(link => link
+        tags: string[],
+    ) {
+        tags.forEach((tag) => {
+            new EditableDataView(tagContainer, component).addLink((link) =>
+                link
                     .setValue(tag)
-                    .setTitle("Tag")
-                    .setLinkType("tag")
+                    .setTitle('Tag')
+                    .setLinkType('tag')
                     .setFormator((value: string) => {
-                        const baseTag = Global.getInstance().settings.baseTag + "/";
+                        const baseTag =
+                            Global.getInstance().settings.baseTag + '/';
                         let valueReduced = value;
-                        if (valueReduced && valueReduced !== "" && valueReduced.startsWith(baseTag)) {
-                            valueReduced = valueReduced.substring(baseTag.length);
+
+                        if (
+                            valueReduced &&
+                            valueReduced !== '' &&
+                            valueReduced.startsWith(baseTag)
+                        ) {
+                            valueReduced = valueReduced.substring(
+                                baseTag.length,
+                            );
                         }
+
                         return { href: `#${value}`, text: `#${valueReduced}` };
-                    })
-                );
+                    }),
+            );
         });
     }
-
 }

--- a/src/libs/BlockRenderComponents/InnerComponents/MaxShownModelsInput.ts
+++ b/src/libs/BlockRenderComponents/InnerComponents/MaxShownModelsInput.ts
@@ -1,18 +1,17 @@
-import { Component, setIcon } from "obsidian";
-import Global from "src/classes/Global";
-import Lng from "src/classes/Lng";
+import { Component, setIcon } from 'obsidian';
+import Global from 'src/classes/Global';
+import Lng from 'src/classes/Lng';
 
 /**
  * Max shown models input component class for `TableBlockRenderComponent`.
- * 
+ *
  * This class provides methods to create and manage a max shown models input component.
  * It includes functionality for setting up the max shown models input and handling input events.
- * 
+ *
  * @see {@link create} for details about creating a max shown models input component.
  * @see {@link MaxShownModelsCallback} for details about the max shown models callback.
  */
 export default class MaxShownModelsInput {
-
     /**
      * Creates a new max shown models input component.
      * @param component The component to register the events to.
@@ -27,30 +26,50 @@ export default class MaxShownModelsInput {
      * - `minus-batch-button` - The minus symbol of the max shown models input component.
      * - `plus-batch-button` - The plus symbol of the max shown models input component.
      */
-    public static create(component: Component, defaultValue: number, batchSize: number, onChange: MaxShownModelsCallback): DocumentFragment {
+    public static create(
+        component: Component,
+        defaultValue: number,
+        batchSize: number,
+        onChange: MaxShownModelsCallback,
+    ): DocumentFragment {
         const headerItemContainer = document.createDocumentFragment();
         const logger = Global.getInstance().logger;
         let debounceTimer: NodeJS.Timeout;
 
         const maxShownModels: MaxShownModelNumber = {
-            maxShownModels: !isNaN(parseFloat(defaultValue as unknown as string)) && isFinite(defaultValue) ? Number(defaultValue) : 0
+            maxShownModels:
+                !isNaN(parseFloat(defaultValue as unknown as string)) &&
+                isFinite(defaultValue)
+                    ? Number(defaultValue)
+                    : 0,
         };
 
         const filterMaxModelsContainer = document.createElement('div');
         headerItemContainer.appendChild(filterMaxModelsContainer);
         filterMaxModelsContainer.classList.add('filter-max-models');
 
-        const number = this.createNumberPresentation(maxShownModels, component, batchSize);
+        const number = this.createNumberPresentation(
+            maxShownModels,
+            component,
+            batchSize,
+        );
 
         const debounceOnChange = () => {
             clearTimeout(debounceTimer);
+
             debounceTimer = setTimeout(async () => {
                 try {
-                    maxShownModels.maxShownModels = (await onChange(maxShownModels.maxShownModels)) ?? maxShownModels.maxShownModels;
+                    maxShownModels.maxShownModels =
+                        (await onChange(maxShownModels.maxShownModels)) ??
+                        maxShownModels.maxShownModels;
                 } catch (error) {
-                    logger.error("The `onChange` callback threw an error!", error);
+                    logger.error(
+                        'The `onChange` callback threw an error!',
+                        error,
+                    );
                 } finally {
-                    number.number.textContent = maxShownModels.maxShownModels.toString();
+                    number.number.textContent =
+                        maxShownModels.maxShownModels.toString();
                 }
             }, 500);
         };
@@ -60,22 +79,26 @@ export default class MaxShownModelsInput {
             number.number,
             maxShownModels,
             batchSize,
-            debounceOnChange);
+            debounceOnChange,
+        );
 
         const minus = this.createSymbol(
-            "minus",
+            'minus',
             number.number,
             component,
             maxShownModels,
             batchSize,
-            debounceOnChange);
+            debounceOnChange,
+        );
+
         const plus = this.createSymbol(
-            "plus",
+            'plus',
             number.number,
             component,
             maxShownModels,
             batchSize,
-            debounceOnChange);
+            debounceOnChange,
+        );
 
         filterMaxModelsContainer.appendChild(minus);
         filterMaxModelsContainer.appendChild(number.container);
@@ -94,13 +117,14 @@ export default class MaxShownModelsInput {
     private static createNumberPresentation(
         maxShownModels: MaxShownModelNumber,
         component: Component,
-        batchSize: number): { container: DocumentFragment, number: HTMLSpanElement } {
+        batchSize: number,
+    ): { container: DocumentFragment; number: HTMLSpanElement } {
         const filterMaxModelsContainer = document.createDocumentFragment();
 
         const maxShownNumber = document.createElement('span');
         filterMaxModelsContainer.appendChild(maxShownNumber);
         maxShownNumber.classList.add('filter-max-number');
-        maxShownNumber.title = Lng.gt("MaxShownEntrys");
+        maxShownNumber.title = Lng.gt('MaxShownEntrys');
         maxShownNumber.textContent = maxShownModels.maxShownModels.toString();
 
         return { container: filterMaxModelsContainer, number: maxShownNumber };
@@ -114,15 +138,39 @@ export default class MaxShownModelsInput {
      * @param batchSize The batch size to add or subtract.
      * @param onMaxShownModelsChange The callback to call when the max shown models number changes.
      */
-    private static createNumberPresentationEvent(component: Component, maxShownNumber: HTMLSpanElement, maxShownModels: MaxShownModelNumber, batchSize: number, onMaxShownModelsChange: () => void) {
-        component.registerDomEvent(maxShownNumber, 'wheel', async (event: WheelEvent) => {
-            event.preventDefault();
-            if (event.deltaY > 0) {
-                this.changeValue("minus", maxShownModels, batchSize, maxShownNumber, onMaxShownModelsChange);
-            } else {
-                this.changeValue("plus", maxShownModels, batchSize, maxShownNumber, onMaxShownModelsChange);
-            }
-        }, { passive: false });
+    private static createNumberPresentationEvent(
+        component: Component,
+        maxShownNumber: HTMLSpanElement,
+        maxShownModels: MaxShownModelNumber,
+        batchSize: number,
+        onMaxShownModelsChange: () => void,
+    ) {
+        component.registerDomEvent(
+            maxShownNumber,
+            'wheel',
+            async (event: WheelEvent) => {
+                event.preventDefault();
+
+                if (event.deltaY > 0) {
+                    this.changeValue(
+                        'minus',
+                        maxShownModels,
+                        batchSize,
+                        maxShownNumber,
+                        onMaxShownModelsChange,
+                    );
+                } else {
+                    this.changeValue(
+                        'plus',
+                        maxShownModels,
+                        batchSize,
+                        maxShownNumber,
+                        onMaxShownModelsChange,
+                    );
+                }
+            },
+            { passive: false },
+        );
     }
 
     /**
@@ -138,24 +186,36 @@ export default class MaxShownModelsInput {
      * - The symbol has the class `plus-batch-button` or `minus-batch-button`.
      */
     private static createSymbol(
-        type: "plus" | "minus",
+        type: 'plus' | 'minus',
         maxShownNumber: HTMLSpanElement,
         component: Component,
         maxShownModels: MaxShownModelNumber,
         batchSize: number,
-        onMaxShownModelsChange: () => void): DocumentFragment {
+        onMaxShownModelsChange: () => void,
+    ): DocumentFragment {
         const filterMaxModelsContainer = document.createDocumentFragment();
 
         const maxShownDocMinus = document.createElement('a');
         filterMaxModelsContainer.appendChild(maxShownDocMinus);
         maxShownDocMinus.classList.add(`${type}-batch-button`);
         maxShownDocMinus.title = type;
-        maxShownDocMinus.href = "#";
+        maxShownDocMinus.href = '#';
         setIcon(maxShownDocMinus, type);
 
-        component.registerDomEvent(maxShownDocMinus, 'click', async (event: MouseEvent) => {
-            this.changeValue(type, maxShownModels, batchSize, maxShownNumber, onMaxShownModelsChange);
-        });
+        component.registerDomEvent(
+            maxShownDocMinus,
+            'click',
+            async (event: MouseEvent) => {
+                this.changeValue(
+                    type,
+                    maxShownModels,
+                    batchSize,
+                    maxShownNumber,
+                    onMaxShownModelsChange,
+                );
+            },
+        );
+
         return filterMaxModelsContainer;
     }
 
@@ -167,17 +227,25 @@ export default class MaxShownModelsInput {
      * @param maxShownNumber The presentation span of the max shown models number.
      * @param onMaxShownModelsChange The callback to call when the max shown models number changes.
      */
-    private static changeValue(type: string, maxShownModels: MaxShownModelNumber, batchSize: number, maxShownNumber: HTMLSpanElement, onMaxShownModelsChange: () => void) {
-        if (type === "minus") {
+    private static changeValue(
+        type: string,
+        maxShownModels: MaxShownModelNumber,
+        batchSize: number,
+        maxShownNumber: HTMLSpanElement,
+        onMaxShownModelsChange: () => void,
+    ) {
+        if (type === 'minus') {
             if (maxShownModels.maxShownModels >= batchSize) {
                 // Subtracts either the remainder (to arrive at the next multiple of `batchSize`) or `batchSize` itself
-                maxShownModels.maxShownModels -= (maxShownModels.maxShownModels % batchSize) || batchSize;
+                maxShownModels.maxShownModels -=
+                    maxShownModels.maxShownModels % batchSize || batchSize;
             } else {
                 maxShownModels.maxShownModels = 0;
             }
         } else {
             // Adds either the remainder (to arrive at the next multiple of `batchSize`) or `batchSize` itself
-            maxShownModels.maxShownModels += batchSize - (maxShownModels.maxShownModels % batchSize);
+            maxShownModels.maxShownModels +=
+                batchSize - (maxShownModels.maxShownModels % batchSize);
         }
         maxShownNumber.textContent = maxShownModels.maxShownModels.toString();
         onMaxShownModelsChange();
@@ -198,4 +266,4 @@ type MaxShownModelsCallback = (value: number) => Promise<number | undefined>;
  * @param maxShownModels The max shown models number.
  * @remarks The container is used to pass the max shown models number by reference.
  */
-type MaxShownModelNumber = { maxShownModels: number }
+type MaxShownModelNumber = { maxShownModels: number };

--- a/src/libs/BlockRenderComponents/InnerComponents/ProjectComponents.ts
+++ b/src/libs/BlockRenderComponents/InnerComponents/ProjectComponents.ts
@@ -1,14 +1,13 @@
-import { Component, MarkdownRenderer, setIcon } from "obsidian";
-import Global from "src/classes/Global";
-import Lng from "src/classes/Lng";
-import EditableDataView from "src/libs/EditableDataView/EditableDataView";
-import Helper from "src/libs/Helper";
+import { Component, MarkdownRenderer, setIcon } from 'obsidian';
+import Global from 'src/classes/Global';
+import Lng from 'src/classes/Lng';
+import EditableDataView from 'src/libs/EditableDataView/EditableDataView';
+import Helper from 'src/libs/Helper';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { PrjTaskManagementModel } from "src/models/PrjTaskManagementModel";
-import { FileType, Status, UrgencySymbols } from "src/types/PrjTypes";
+import { PrjTaskManagementModel } from 'src/models/PrjTaskManagementModel';
+import { FileType, Status, UrgencySymbols } from 'src/types/PrjTypes';
 
 export default class ProjectComponents {
-
     /**
      * Creates a title component.
      * @param container The container to append the title to.
@@ -22,32 +21,46 @@ export default class ProjectComponents {
         component: Component,
         path: string,
         onRead: () => string,
-        onWrite: (value: string) => void) {
-        new EditableDataView(container, component)
-            .addLink(link => {
-                link.setValue(onRead())
-                    .setTitle(Lng.gt("Title"))
-                    .setPlaceholder(Lng.gt("Title"))
-                    .setLinkType("file")
-                    .setFormator((value: string) => {
-                        let title: DocumentFragment | undefined = document.createDocumentFragment();
-                        if (value === "") {
-                            setIcon(title as unknown as HTMLDivElement, "paperclip");
-                        } else if (Helper.isPossiblyMarkdown(value)) {
-                            const div = document.createElement('div');
-                            MarkdownRenderer.render(Global.getInstance().app, value ?? "", div, "", component);
-                            title.appendChild(div);
-                        } else {
-                            title = undefined
-                        }
-                        return { href: `${path}`, text: `${value}`, html: title };
-                    })
-                    .enableEditability()
-                    .onSave((value: string) => {
-                        onWrite(value);
-                        return Promise.resolve();
-                    });
-            });
+        onWrite: (value: string) => void,
+    ) {
+        new EditableDataView(container, component).addLink((link) => {
+            link.setValue(onRead())
+                .setTitle(Lng.gt('Title'))
+                .setPlaceholder(Lng.gt('Title'))
+                .setLinkType('file')
+                .setFormator((value: string) => {
+                    let title: DocumentFragment | undefined =
+                        document.createDocumentFragment();
+
+                    if (value === '') {
+                        setIcon(
+                            title as unknown as HTMLDivElement,
+                            'paperclip',
+                        );
+                    } else if (Helper.isPossiblyMarkdown(value)) {
+                        const div = document.createElement('div');
+
+                        MarkdownRenderer.render(
+                            Global.getInstance().app,
+                            value ?? '',
+                            div,
+                            '',
+                            component,
+                        );
+                        title.appendChild(div);
+                    } else {
+                        title = undefined;
+                    }
+
+                    return { href: `${path}`, text: `${value}`, html: title };
+                })
+                .enableEditability()
+                .onSave((value: string) => {
+                    onWrite(value);
+
+                    return Promise.resolve();
+                });
+        });
     }
 
     /**
@@ -61,36 +74,39 @@ export default class ProjectComponents {
         container: DocumentFragment,
         component: Component,
         description: string,
-        onWrite: (value: string) => void) {
-        new EditableDataView(container, component)
-            .addTextarea(text => text
+        onWrite: (value: string) => void,
+    ) {
+        new EditableDataView(container, component).addTextarea((text) =>
+            text
                 .setValue(description)
-                .setTitle(Lng.gt("Description"))
-                .setPlaceholder(Lng.gt("Description"))
+                .setTitle(Lng.gt('Description'))
+                .setPlaceholder(Lng.gt('Description'))
                 .enableEditability()
                 .setRenderMarkdown()
                 .onSave((value: string) => {
                     onWrite(value);
+
                     return Promise.resolve();
-                })
-            );
+                }),
+        );
     }
 
     public static createStatus(
         container: DocumentFragment,
         component: Component,
         onRead: () => string,
-        onWrite: (value: string) => void) {
-        new EditableDataView(container, component)
-            .addDropdown(dropdown => dropdown
+        onWrite: (value: string) => void,
+    ) {
+        new EditableDataView(container, component).addDropdown((dropdown) =>
+            dropdown
                 .setOptions([
-                    { value: "Active", text: Lng.gt("StatusActive") },
-                    { value: "Waiting", text: Lng.gt("StatusWaiting") },
-                    { value: "Later", text: Lng.gt("StatusLater") },
-                    { value: "Someday", text: Lng.gt("StatusSomeday") },
-                    { value: "Done", text: Lng.gt("StatusDone") }
+                    { value: 'Active', text: Lng.gt('StatusActive') },
+                    { value: 'Waiting', text: Lng.gt('StatusWaiting') },
+                    { value: 'Later', text: Lng.gt('StatusLater') },
+                    { value: 'Someday', text: Lng.gt('StatusSomeday') },
+                    { value: 'Done', text: Lng.gt('StatusDone') },
                 ])
-                .setTitle(Lng.gt("Status"))
+                .setTitle(Lng.gt('Status'))
                 .setValue(onRead())
                 .onSave(async (value) => {
                     onWrite(value);
@@ -99,29 +115,31 @@ export default class ProjectComponents {
                 .setFormator((value: string) => {
                     const status = value as Status;
                     let iconString: string;
+
                     switch (status) {
-                        case "Active":
-                            iconString = "⚡";
+                        case 'Active':
+                            iconString = '⚡';
                             break;
-                        case "Waiting":
-                            iconString = "⏳";
+                        case 'Waiting':
+                            iconString = '⏳';
                             break;
-                        case "Later":
-                            iconString = "🔜";
+                        case 'Later':
+                            iconString = '🔜';
                             break;
-                        case "Someday":
-                            iconString = "📆";
+                        case 'Someday':
+                            iconString = '📆';
                             break;
-                        case "Done":
-                            iconString = "✔️";
+                        case 'Done':
+                            iconString = '✔️';
                             break;
                         default:
-                            iconString = "⚡";
+                            iconString = '⚡';
                             break;
                     }
+
                     return { text: `${iconString}`, html: undefined };
-                }
-                ));
+                }),
+        );
     }
 
     /**
@@ -135,16 +153,17 @@ export default class ProjectComponents {
         container: DocumentFragment,
         component: Component,
         onRead: () => string,
-        onWrite: (value: string) => void) {
-        new EditableDataView(container, component)
-            .addDropdown(dropdown => dropdown
+        onWrite: (value: string) => void,
+    ) {
+        new EditableDataView(container, component).addDropdown((dropdown) =>
+            dropdown
                 .setOptions([
-                    { value: "3", text: Lng.gt("HighPriority") },
-                    { value: "2", text: Lng.gt("MediumPriority") },
-                    { value: "1", text: Lng.gt("LowPriority") },
-                    { value: "0", text: Lng.gt("NoPriority") }
+                    { value: '3', text: Lng.gt('HighPriority') },
+                    { value: '2', text: Lng.gt('MediumPriority') },
+                    { value: '1', text: Lng.gt('LowPriority') },
+                    { value: '0', text: Lng.gt('NoPriority') },
                 ])
-                .setTitle(Lng.gt("PriorityText"))
+                .setTitle(Lng.gt('PriorityText'))
                 .setValue(onRead())
                 .onSave(async (value) => {
                     onWrite(value);
@@ -153,27 +172,29 @@ export default class ProjectComponents {
                 .setFormator((value: string) => {
                     const icon = document.createDocumentFragment();
                     let iconString: string;
+
                     switch (value) {
-                        case "3":
-                            iconString = "signal";
+                        case '3':
+                            iconString = 'signal';
                             break;
-                        case "2":
-                            iconString = "signal-medium";
+                        case '2':
+                            iconString = 'signal-medium';
                             break;
-                        case "1":
-                            iconString = "signal-low";
+                        case '1':
+                            iconString = 'signal-low';
                             break;
-                        case "0":
-                            iconString = "signal-zero";
+                        case '0':
+                            iconString = 'signal-zero';
                             break;
                         default:
-                            iconString = "signal-zero";
+                            iconString = 'signal-zero';
                             break;
                     }
                     setIcon(icon as unknown as HTMLDivElement, iconString);
+
                     return { text: `${value}`, html: icon };
-                }
-                ));
+                }),
+        );
     }
 
     /**
@@ -189,19 +210,21 @@ export default class ProjectComponents {
         component: Component,
         path: string,
         type: FileType | undefined | null,
-        corospondingSymbol: string) {
-        new EditableDataView(container, component)
-            .addLink(link => link
+        corospondingSymbol: string,
+    ) {
+        new EditableDataView(container, component).addLink((link) =>
+            link
                 .setValue(path)
-                .setTitle(Lng.gt(type ?? "File"))
-                .setLinkType("file")
+                .setTitle(Lng.gt(type ?? 'File'))
+                .setLinkType('file')
                 .setFormator((value: string) => {
                     const icon = document.createDocumentFragment();
                     const iconString = corospondingSymbol;
                     setIcon(icon as unknown as HTMLDivElement, iconString);
+
                     return { href: `${value}`, text: `${value}`, html: icon };
-                }
-                ));
+                }),
+        );
     }
 
     /**
@@ -213,31 +236,33 @@ export default class ProjectComponents {
      */
     public static createTraficLight(
         container: DocumentFragment,
-        urgency: number) {
+        urgency: number,
+    ) {
         const traficLightSpan = document.createElement('span');
         container.appendChild(traficLightSpan);
         let iconString: UrgencySymbols;
+
         switch (urgency) {
             case 3:
-                iconString = "🔴";
+                iconString = '🔴';
                 break;
             case 2:
-                iconString = "🟠";
+                iconString = '🟠';
                 break;
             case 1:
-                iconString = "🟡";
+                iconString = '🟡';
                 break;
             case 0:
-                iconString = "🟢";
+                iconString = '🟢';
                 break;
             case -1:
-                iconString = "🟢";
+                iconString = '🟢';
                 break;
             case -2:
-                iconString = "🔵";
+                iconString = '🔵';
                 break;
             default:
-                iconString = "🔴";
+                iconString = '🔴';
                 break;
         }
         traficLightSpan.textContent = iconString;

--- a/src/libs/BlockRenderComponents/InnerComponents/SearchInput.ts
+++ b/src/libs/BlockRenderComponents/InnerComponents/SearchInput.ts
@@ -1,6 +1,6 @@
-import { Component } from "obsidian";
-import Global from "src/classes/Global";
-import Lng from "src/classes/Lng";
+import { Component } from 'obsidian';
+import Global from 'src/classes/Global';
+import Lng from 'src/classes/Lng';
 
 /**
  * Search input component class for `TableBlockRenderComponent`.
@@ -24,7 +24,11 @@ export default class SearchInput {
      *  - `search-box-sizer` - The sizer of the search input component.
      *  - `search-box` - The search box of the search input component.
      */
-    public static create(component: Component, onSearch: SearchCallback, defaultText?: string): DocumentFragment {
+    public static create(
+        component: Component,
+        onSearch: SearchCallback,
+        defaultText?: string,
+    ): DocumentFragment {
         const logger = Global.getInstance().logger;
         const headerItemContainer = document.createDocumentFragment();
 
@@ -33,7 +37,9 @@ export default class SearchInput {
         searchLabelContainer.classList.add('filter-search');
 
         SearchInput.createSearchLabel(searchLabelContainer);
-        const searchBoxSizer = SearchInput.createSearchBoxSizer(searchLabelContainer);
+
+        const searchBoxSizer =
+            SearchInput.createSearchBoxSizer(searchLabelContainer);
         const searchBoxInput = SearchInput.createSearchBoxInput(searchBoxSizer);
 
         if (defaultText) {
@@ -44,32 +50,47 @@ export default class SearchInput {
         /**
          * Register input event to set the search box sizer value.
          */
-        component.registerDomEvent(searchBoxInput, 'input', async (event: InputEvent) => {
-            this.setSearchBoxSizerValue(searchBoxSizer, searchBoxInput.value);
-        });
+        component.registerDomEvent(
+            searchBoxInput,
+            'input',
+            async (event: InputEvent) => {
+                this.setSearchBoxSizerValue(
+                    searchBoxSizer,
+                    searchBoxInput.value,
+                );
+            },
+        );
 
         /**
          * Register keydown event to call the search callback.
          * @remarks - The return value of the callback is used to set the search box value and the search box sizer value.
          */
-        component.registerDomEvent(searchBoxInput, 'keydown', async (event: KeyboardEvent) => {
-            let value = searchBoxInput.value;
-            try {
-                value = await onSearch(searchBoxInput.value, event.key);
-            } catch (error) {
-                logger.error("The `onSearch` callback threw an error!", error);
-            } finally {
-                this.setSearchBoxSizerValue(searchBoxSizer, value);
-                this.setSearchBoxInputValue(searchBoxInput, value);
-            }
-        });
+        component.registerDomEvent(
+            searchBoxInput,
+            'keydown',
+            async (event: KeyboardEvent) => {
+                let value = searchBoxInput.value;
+
+                try {
+                    value = await onSearch(searchBoxInput.value, event.key);
+                } catch (error) {
+                    logger.error(
+                        'The `onSearch` callback threw an error!',
+                        error,
+                    );
+                } finally {
+                    this.setSearchBoxSizerValue(searchBoxSizer, value);
+                    this.setSearchBoxInputValue(searchBoxInput, value);
+                }
+            },
+        );
 
         return headerItemContainer;
     }
 
     /**
      * Creates the search label.
-     * @param searchLabelContainer The container to append the label to. 
+     * @param searchLabelContainer The container to append the label to.
      * @remarks - The label is a `HTMLSpanElement`.
      * - The label text is `Search`-value of the translation.
      * - The label element has the class `filter-text`.
@@ -78,7 +99,7 @@ export default class SearchInput {
         const filterLabel = document.createElement('span');
         searchLabelContainer.appendChild(filterLabel);
         filterLabel.classList.add('filter-text');
-        filterLabel.textContent = Lng.gt("Search") + ":";
+        filterLabel.textContent = Lng.gt('Search') + ':';
     }
 
     /**
@@ -92,6 +113,7 @@ export default class SearchInput {
         const searchBoxSizer = document.createElement('label');
         searchLabelContainer.appendChild(searchBoxSizer);
         searchBoxSizer.classList.add('search-box-sizer');
+
         return searchBoxSizer;
     }
 
@@ -108,9 +130,10 @@ export default class SearchInput {
         const searchBoxInput = document.createElement('input');
         searchBoxSizer.appendChild(searchBoxInput);
         searchBoxInput.classList.add('search-box');
-        searchBoxInput.type = "text";
-        searchBoxInput.placeholder = Lng.gt("Search");
-        searchBoxInput.value = "";
+        searchBoxInput.type = 'text';
+        searchBoxInput.placeholder = Lng.gt('Search');
+        searchBoxInput.value = '';
+
         return searchBoxInput;
     }
 
@@ -119,8 +142,11 @@ export default class SearchInput {
      * @param searchBoxSizer The search box sizer to set the value to.
      * @param value The value to set.
      */
-    private static setSearchBoxSizerValue(searchBoxSizer: HTMLElement, value: string) {
-        searchBoxSizer.dataset.value = "_" + value + "_";
+    private static setSearchBoxSizerValue(
+        searchBoxSizer: HTMLElement,
+        value: string,
+    ) {
+        searchBoxSizer.dataset.value = '_' + value + '_';
     }
 
     /**
@@ -128,7 +154,10 @@ export default class SearchInput {
      * @param searchBoxInput The search box input to set the value to.
      * @param value The value to set.
      */
-    private static setSearchBoxInputValue(searchBoxInput: HTMLInputElement, value: string) {
+    private static setSearchBoxInputValue(
+        searchBoxInput: HTMLInputElement,
+        value: string,
+    ) {
         searchBoxInput.value = value;
     }
 }
@@ -142,4 +171,7 @@ export default class SearchInput {
  * - Start search on `Enter` key.
  * - Clear search on `Escape` key.
  */
-type SearchCallback = (searchboxValue: string, eventKey: string) => Promise<string>;
+type SearchCallback = (
+    searchboxValue: string,
+    eventKey: string,
+) => Promise<string>;

--- a/src/libs/BlockRenderComponents/NoteBlockRenderComponent.ts
+++ b/src/libs/BlockRenderComponents/NoteBlockRenderComponent.ts
@@ -1,18 +1,20 @@
-import { DocumentModel } from "src/models/DocumentModel";
-import TableBlockRenderComponent, { BlockRenderSettings } from "./TableBlockRenderComponent";
-import { IProcessorSettings } from "../../interfaces/IProcessorSettings";
-import Search from "../Search";
-import Table, { Row, RowsState, TableHeader } from "../Table";
-import Lng from "src/classes/Lng";
-import MaxShownModelsInput from "./InnerComponents/MaxShownModelsInput";
-import SearchInput from "./InnerComponents/SearchInput";
-import Helper from "../Helper";
-import GeneralComponents from "./InnerComponents/GeneralComponents";
-import API from "src/classes/API";
-import { FileMetadata } from "../MetadataCache";
-import { NoteModel } from "src/models/NoteModel";
-import ProjectComponents from "./InnerComponents/ProjectComponents";
-import EditableDataView from "../EditableDataView/EditableDataView";
+import { DocumentModel } from 'src/models/DocumentModel';
+import TableBlockRenderComponent, {
+    BlockRenderSettings,
+} from './TableBlockRenderComponent';
+import { IProcessorSettings } from '../../interfaces/IProcessorSettings';
+import Search from '../Search';
+import Table, { Row, RowsState, TableHeader } from '../Table';
+import Lng from 'src/classes/Lng';
+import MaxShownModelsInput from './InnerComponents/MaxShownModelsInput';
+import SearchInput from './InnerComponents/SearchInput';
+import Helper from '../Helper';
+import GeneralComponents from './InnerComponents/GeneralComponents';
+import API from 'src/classes/API';
+import { FileMetadata } from '../MetadataCache';
+import { NoteModel } from 'src/models/NoteModel';
+import ProjectComponents from './InnerComponents/ProjectComponents';
+import EditableDataView from '../EditableDataView/EditableDataView';
 
 /**
  * Document block render component class for `TableBlockRenderComponent`.
@@ -23,24 +25,28 @@ export default class NoteBlockRenderComponent extends TableBlockRenderComponent<
     protected settings: BlockRenderSettings = {
         tags: [],
         reactOnActiveFile: false,
-        filter: ["Note"],
+        filter: ['Note'],
         maxDocuments: this.global.settings.defaultMaxShow,
         search: undefined,
         searchText: undefined,
         batchSize: 8,
-        sleepBetweenBatches: 10
+        sleepBetweenBatches: 10,
     };
 
     /**
      * The table headers.
      * @remarks The table headers are used to create the table.
-     * 
+     *
      */
     protected tableHeaders: TableHeader[] = [
-        { text: Lng.gt("Date"), headerClass: [], columnClass: ["font-xsmall"] },
-        { text: Lng.gt("Notice"), headerClass: [], columnClass: [] },
-        { text: Lng.gt("Description"), headerClass: [], columnClass: ["font-xsmall"] },
-        { text: Lng.gt("Tags"), headerClass: [], columnClass: ["tags"] }
+        { text: Lng.gt('Date'), headerClass: [], columnClass: ['font-xsmall'] },
+        { text: Lng.gt('Notice'), headerClass: [], columnClass: [] },
+        {
+            text: Lng.gt('Description'),
+            headerClass: [],
+            columnClass: ['font-xsmall'],
+        },
+        { text: Lng.gt('Tags'), headerClass: [], columnClass: ['tags'] },
     ];
 
     constructor(settings: IProcessorSettings) {
@@ -66,18 +72,24 @@ export default class NoteBlockRenderComponent extends TableBlockRenderComponent<
         const documentsPromise = super.getModels(
             ['Note'],
             this.settings.tags,
-            (metadata: FileMetadata) => new NoteModel(metadata.file));
+            (metadata: FileMetadata) => new NoteModel(metadata.file),
+        );
         await super.draw();
         await this.buildTable();
         await this.buildHeader();
         this.grayOutHeader();
-        this.models = (await documentsPromise);
+        this.models = await documentsPromise;
 
-        API.documentModel.sortDocumentsByDateDesc(this.models as unknown as DocumentModel[]);
+        API.documentModel.sortDocumentsByDateDesc(
+            this.models as unknown as DocumentModel[],
+        );
         await this.addDocumentsToTable();
         this.normalizeHeader();
         const endTime = Date.now();
-        this.logger.debug(`Redraw Documents (for ${this.models.length} Docs.) runs for ${endTime - startTime}ms`);
+
+        this.logger.debug(
+            `Redraw Documents (for ${this.models.length} Docs.) runs for ${endTime - startTime}ms`,
+        );
     }
 
     /**
@@ -102,19 +114,21 @@ export default class NoteBlockRenderComponent extends TableBlockRenderComponent<
         const filterLabel = document.createElement('span');
         filterLabelContainer.appendChild(filterLabel);
         filterLabel.classList.add('filter-symbol');
-        filterLabel.textContent = Lng.gt("Filter");
+        filterLabel.textContent = Lng.gt('Filter');
 
         const maxDocuments = MaxShownModelsInput.create(
             this.component,
             this.settings.maxDocuments,
             this.global.settings.defaultMaxShow,
-            this.onMaxDocumentsChange.bind(this));
+            this.onMaxDocumentsChange.bind(this),
+        );
         headerFilterButtons.appendChild(maxDocuments);
 
         const searchBox = SearchInput.create(
             this.component,
             this.onSearch.bind(this),
-            this.settings.searchText);
+            this.settings.searchText,
+        );
         headerFilterButtons.appendChild(searchBox);
     }
 
@@ -124,9 +138,12 @@ export default class NoteBlockRenderComponent extends TableBlockRenderComponent<
      * @returns A promise which is resolved when the documents are filtered.
      * @remarks Runs the `onFilter` method.
      */
-    private async onMaxDocumentsChange(maxDocuments: number): Promise<undefined> {
+    private async onMaxDocumentsChange(
+        maxDocuments: number,
+    ): Promise<undefined> {
         this.settings.maxDocuments = maxDocuments;
         this.onFilter();
+
         return undefined;
     }
 
@@ -140,8 +157,8 @@ export default class NoteBlockRenderComponent extends TableBlockRenderComponent<
      * - After the search is applied, the `onFilter` method is called.
      */
     private async onSearch(search: string, key: string): Promise<string> {
-        if (key === "Enter") {
-            if (search !== "") {
+        if (key === 'Enter') {
+            if (search !== '') {
                 this.settings.searchText = search;
                 this.settings.search = Search.parseSearchText(search);
                 this.onFilter();
@@ -150,19 +167,21 @@ export default class NoteBlockRenderComponent extends TableBlockRenderComponent<
                 this.settings.search = undefined;
                 this.onFilter();
             }
-        } else if (key === "Escape") {
+        } else if (key === 'Escape') {
             this.settings.searchText = undefined;
             this.settings.search = undefined;
             this.onFilter();
-            return "";
+
+            return '';
         }
+
         return search;
     }
 
     /**
      * Filters the documents and shows/hides them in the table.
      * @remarks - The documents are filtered by the `filter` setting,
-     * searched by the `search` setting 
+     * searched by the `search` setting
      * and the number of documents is limited by the `maxDocuments` if no search is applied.
      */
     private async onFilter() {
@@ -180,11 +199,18 @@ export default class NoteBlockRenderComponent extends TableBlockRenderComponent<
             const rowUid = this.getUID(document);
             let hide = this.determineTagHideState(document);
             this.logger.trace(`Document ${rowUid} is hidden by state: ${hide}`);
-            this.logger.trace(`Visible rows: ${visibleRows}; Max shown Docs: ${this.settings.maxDocuments}`);
+
+            this.logger.trace(
+                `Visible rows: ${visibleRows}; Max shown Docs: ${this.settings.maxDocuments}`,
+            );
+
             if (visibleRows >= this.settings.maxDocuments) {
-                hide = true
+                hide = true;
             }
-            this.logger.trace(`Document ${rowUid} is hidden by max counts: ${hide}`);
+
+            this.logger.trace(
+                `Document ${rowUid} is hidden by max counts: ${hide}`,
+            );
 
             if (hide) {
                 rows.push({ rowUid, hidden: true });
@@ -195,7 +221,10 @@ export default class NoteBlockRenderComponent extends TableBlockRenderComponent<
 
             if ((i !== 0 && i % batchSize === 0) || i === documentsLength - 1) {
                 await sleepPromise;
-                this.logger.trace(`Batchsize reached. Change rows: ${rows.length}`);
+
+                this.logger.trace(
+                    `Batchsize reached. Change rows: ${rows.length}`,
+                );
                 await this.table.changeShowHideStateRows(rows);
                 rows.length = 0;
                 sleepPromise = Helper.sleep(sleepBetweenBatches);
@@ -214,7 +243,10 @@ export default class NoteBlockRenderComponent extends TableBlockRenderComponent<
      * - The batch size is defined in the `batchSize` parameter. Default is `settings.batchSize`.
      * - The sleep time between the batches is defined in the `sleepBetweenBatches` parameter. Default is `settings.sleepBetweenBatches`.
      */
-    private async addDocumentsToTable(batchSize = this.settings.batchSize, sleepBetweenBatches = this.settings.sleepBetweenBatches): Promise<void> {
+    private async addDocumentsToTable(
+        batchSize = this.settings.batchSize,
+        sleepBetweenBatches = this.settings.sleepBetweenBatches,
+    ): Promise<void> {
         let sleepPromise = Promise.resolve();
         const documentsLength = this.models.length;
         const rows: Row[] = [];
@@ -229,7 +261,8 @@ export default class NoteBlockRenderComponent extends TableBlockRenderComponent<
         let visibleRows = 0;
 
         for (let i = 0; i < documentsLength; i++) {
-            const document = i + 1 < documentsLength ? this.models[i + 1] : null;
+            const document =
+                i + 1 < documentsLength ? this.models[i + 1] : null;
 
             const row = await rowPromise;
             rowPromise = document ? this.generateTableRow(document) : undefined;
@@ -242,8 +275,7 @@ export default class NoteBlockRenderComponent extends TableBlockRenderComponent<
                 }
             }
 
-            if (row)
-                rows.push(row);
+            if (row) rows.push(row);
 
             if ((i !== 0 && i % batchSize === 0) || i === documentsLength - 1) {
                 await sleepPromise;
@@ -267,59 +299,75 @@ export default class NoteBlockRenderComponent extends TableBlockRenderComponent<
         // Row 0 -- Date
         const date = document.createDocumentFragment();
         rowData.push(date);
+
         GeneralComponents.createCellDate(
             date,
             this.component,
-            Lng.gt("DocumentDate"),
+            Lng.gt('DocumentDate'),
             this.global.settings.dateFormat,
-            () => noteModel.data.date ?? "na",
-            async (value: string) => noteModel.data.date = value);
+            () => noteModel.data.date ?? 'na',
+            async (value: string) => (noteModel.data.date = value),
+        );
 
         // Row 1 -- File Link & Title
         const fileLink = document.createDocumentFragment();
         rowData.push(fileLink);
-        new EditableDataView(fileLink, this.component)
-            .addLink(link => link
-                .setValue(noteModel.data.title ?? "na")
-                .setTitle("Note")
-                .setLinkType("file")
+
+        new EditableDataView(fileLink, this.component).addLink((link) =>
+            link
+                .setValue(noteModel.data.title ?? 'na')
+                .setTitle('Note')
+                .setLinkType('file')
                 .setFormator((value: string) => {
-                    return { href: `${noteModel.file.path}`, text: `${value}`, html: undefined };
+                    return {
+                        href: `${noteModel.file.path}`,
+                        text: `${value}`,
+                        html: undefined,
+                    };
                 })
                 .enableEditability()
                 .onSave((value: string) => {
                     noteModel.data.title = value;
+
                     return Promise.resolve();
-                }));
+                }),
+        );
 
         // Row 2 -- Description
         const description = document.createDocumentFragment();
         rowData.push(description);
+
         ProjectComponents.createSummary(
             description,
             this.component,
-            noteModel.data.description ?? "",
-            async (value: string) => noteModel.data.description = value);
+            noteModel.data.description ?? '',
+            async (value: string) => (noteModel.data.description = value),
+        );
 
         // Row 3 -- Tags
         const tags = document.createDocumentFragment();
         rowData.push(tags);
+
         GeneralComponents.createCellTags(
             tags,
             this.component,
-            noteModel.getTags());
-
+            noteModel.getTags(),
+        );
 
         const row = {
             rowUid,
             rowData,
             rowClassList,
-            hidden: false
+            hidden: false,
         };
+
         return row;
     }
 
-    private getHideState(document: DocumentModel, maxVisibleRows: number | undefined): boolean {
+    private getHideState(
+        document: DocumentModel,
+        maxVisibleRows: number | undefined,
+    ): boolean {
         let searchResult = false;
         let maxRows = false;
 
@@ -347,7 +395,9 @@ export default class NoteBlockRenderComponent extends TableBlockRenderComponent<
     }
 
     private determineTagHideState(document: NoteModel): boolean {
-        return this.settings.reactOnActiveFile ? !Helper.isTagIncluded(this.settings.tags, document.getTags()) : false;
+        return this.settings.reactOnActiveFile
+            ? !Helper.isTagIncluded(this.settings.tags, document.getTags())
+            : false;
     }
 
     public onActiveFileFilter() {
@@ -362,12 +412,11 @@ export default class NoteBlockRenderComponent extends TableBlockRenderComponent<
      * - The table has the headers from the `tableHeaders` property.
      */
     private async buildTable(): Promise<void> {
-        this.table = new Table(this.tableHeaders, "document-table", undefined);
+        this.table = new Table(this.tableHeaders, 'document-table', undefined);
         this.tableContainer.appendChild(this.table.data.table);
     }
 
     public redraw(): Promise<void> {
         return super.redraw();
     }
-
 }

--- a/src/libs/BlockRenderComponents/ProjectBlockRenderComponent.ts
+++ b/src/libs/BlockRenderComponents/ProjectBlockRenderComponent.ts
@@ -1,49 +1,65 @@
-import TableBlockRenderComponent, { BlockRenderSettings } from "./TableBlockRenderComponent";
-import { PrjTaskManagementModel } from "src/models/PrjTaskManagementModel";
-import TaskData from "src/types/TaskData";
-import TopicData from "src/types/TopicData";
-import ProjectData from "src/types/ProjectData";
-import { IProcessorSettings } from "src/interfaces/IProcessorSettings";
-import Search from "../Search";
-import Table, { Row, RowsState, TableHeader } from "../Table";
-import Lng from "src/classes/Lng";
-import FilterButton from "./InnerComponents/FilterButton";
-import MaxShownModelsInput from "./InnerComponents/MaxShownModelsInput";
-import SearchInput from "./InnerComponents/SearchInput";
-import Helper from "../Helper";
-import { Priority, Status } from "src/types/PrjTypes";
-import ProjectComponents from "./InnerComponents/ProjectComponents";
-import GeneralComponents from "./InnerComponents/GeneralComponents";
-import API from "src/classes/API";
-import { FileMetadata } from "../MetadataCache";
-import { StaticPrjTaskManagementModel } from "src/models/StaticHelper/StaticPrjTaskManagementModel";
+import TableBlockRenderComponent, {
+    BlockRenderSettings,
+} from './TableBlockRenderComponent';
+import { PrjTaskManagementModel } from 'src/models/PrjTaskManagementModel';
+import TaskData from 'src/types/TaskData';
+import TopicData from 'src/types/TopicData';
+import ProjectData from 'src/types/ProjectData';
+import { IProcessorSettings } from 'src/interfaces/IProcessorSettings';
+import Search from '../Search';
+import Table, { Row, RowsState, TableHeader } from '../Table';
+import Lng from 'src/classes/Lng';
+import FilterButton from './InnerComponents/FilterButton';
+import MaxShownModelsInput from './InnerComponents/MaxShownModelsInput';
+import SearchInput from './InnerComponents/SearchInput';
+import Helper from '../Helper';
+import { Priority, Status } from 'src/types/PrjTypes';
+import ProjectComponents from './InnerComponents/ProjectComponents';
+import GeneralComponents from './InnerComponents/GeneralComponents';
+import API from 'src/classes/API';
+import { FileMetadata } from '../MetadataCache';
+import { StaticPrjTaskManagementModel } from 'src/models/StaticHelper/StaticPrjTaskManagementModel';
 
-export default class ProjectBlockRenderComponent extends TableBlockRenderComponent<PrjTaskManagementModel<TaskData | TopicData | ProjectData>> {
+export default class ProjectBlockRenderComponent extends TableBlockRenderComponent<
+    PrjTaskManagementModel<TaskData | TopicData | ProjectData>
+> {
     private filterButtonDebounceTimer: NodeJS.Timeout;
     protected settings: BlockRenderSettings = {
         tags: [],
         reactOnActiveFile: false,
-        filter: ["Topic", "Project", "Task"],
+        filter: ['Topic', 'Project', 'Task'],
         maxDocuments: this.global.settings.defaultMaxShow,
         search: undefined,
         searchText: undefined,
         batchSize: 8,
-        sleepBetweenBatches: 10
+        sleepBetweenBatches: 10,
     };
 
     /**
      * The table headers.
      * @remarks The table headers are used to create the table.
-     * 
+     *
      */
     protected tableHeaders: TableHeader[] = [
-        { text: Lng.gt("DocumentType"), headerClass: [], columnClass: ["dont-decorate-link", "font-medium"] },
-        { text: Lng.gt("TraficLight"), headerClass: [], columnClass: [] },
-        { text: Lng.gt("Description"), headerClass: [], columnClass: ["dont-decorate-link", "link-weight-bold"] },
-        { text: Lng.gt("Priority"), headerClass: [], columnClass: [] },
-        { text: Lng.gt("Due date"), headerClass: [], columnClass: ["font-xsmall"] },
-        { text: Lng.gt("Status"), headerClass: [], columnClass: [] },
-        { text: Lng.gt("Tags"), headerClass: [], columnClass: ["tags"] }
+        {
+            text: Lng.gt('DocumentType'),
+            headerClass: [],
+            columnClass: ['dont-decorate-link', 'font-medium'],
+        },
+        { text: Lng.gt('TraficLight'), headerClass: [], columnClass: [] },
+        {
+            text: Lng.gt('Description'),
+            headerClass: [],
+            columnClass: ['dont-decorate-link', 'link-weight-bold'],
+        },
+        { text: Lng.gt('Priority'), headerClass: [], columnClass: [] },
+        {
+            text: Lng.gt('Due date'),
+            headerClass: [],
+            columnClass: ['font-xsmall'],
+        },
+        { text: Lng.gt('Status'), headerClass: [], columnClass: [] },
+        { text: Lng.gt('Tags'), headerClass: [], columnClass: ['tags'] },
     ];
 
     constructor(settings: IProcessorSettings) {
@@ -65,22 +81,33 @@ export default class ProjectBlockRenderComponent extends TableBlockRenderCompone
         const getModelsPromise = super.getModels(
             ['Topic', 'Project', 'Task'],
             this.settings.tags,
-            (metadata: FileMetadata) => StaticPrjTaskManagementModel.getCorospondingModel(metadata.file));
+            (metadata: FileMetadata) =>
+                StaticPrjTaskManagementModel.getCorospondingModel(
+                    metadata.file,
+                ),
+        );
         await super.draw();
         await this.buildTable();
         await this.buildHeader();
         this.grayOutHeader();
-        this.models = (await getModelsPromise);
+        this.models = await getModelsPromise;
 
-        API.prjTaskManagementModel.sortModelsByUrgency(this.models as (PrjTaskManagementModel<TaskData | TopicData | ProjectData>)[]);
+        API.prjTaskManagementModel.sortModelsByUrgency(
+            this.models as PrjTaskManagementModel<
+                TaskData | TopicData | ProjectData
+            >[],
+        );
         await this.addDocumentsToTable();
         this.normalizeHeader();
         const endTime = Date.now();
-        this.logger.debug(`Redraw (for ${this.models.length} Models) runs for ${endTime - startTime}ms`);
+
+        this.logger.debug(
+            `Redraw (for ${this.models.length} Models) runs for ${endTime - startTime}ms`,
+        );
     }
 
     private async buildTable(): Promise<void> {
-        this.table = new Table(this.tableHeaders, "project-table", undefined);
+        this.table = new Table(this.tableHeaders, 'project-table', undefined);
         this.tableContainer.appendChild(this.table.data.table);
     }
 
@@ -97,55 +124,64 @@ export default class ProjectBlockRenderComponent extends TableBlockRenderCompone
         const filterLabel = document.createElement('span');
         filterLabelContainer.appendChild(filterLabel);
         filterLabel.classList.add('filter-symbol');
-        filterLabel.textContent = Lng.gt("Filter");
+        filterLabel.textContent = Lng.gt('Filter');
 
         const topicFilterButton = FilterButton.create(
             this.component,
-            "Topic",
+            'Topic',
             this.globalSettings.prjSettings.topicSymbol,
-            this.settings.filter.includes("Topic"),
-            this.onFilterButton.bind(this));
+            this.settings.filter.includes('Topic'),
+            this.onFilterButton.bind(this),
+        );
         headerFilterButtons.appendChild(topicFilterButton);
 
         const projectFilterButton = FilterButton.create(
             this.component,
-            "Project",
+            'Project',
             this.globalSettings.prjSettings.projectSymbol,
-            this.settings.filter.includes("Project"),
-            this.onFilterButton.bind(this));
+            this.settings.filter.includes('Project'),
+            this.onFilterButton.bind(this),
+        );
         headerFilterButtons.appendChild(projectFilterButton);
 
         const taskFilterButton = FilterButton.create(
             this.component,
-            "Task",
+            'Task',
             this.globalSettings.prjSettings.taskSymbol,
-            this.settings.filter.includes("Task"),
-            this.onFilterButton.bind(this));
+            this.settings.filter.includes('Task'),
+            this.onFilterButton.bind(this),
+        );
         headerFilterButtons.appendChild(taskFilterButton);
 
         const doneFilterButton = FilterButton.create(
             this.component,
-            "Done",
-            "check-square",
-            this.settings.filter.includes("Done"),
-            this.onFilterButton.bind(this));
+            'Done',
+            'check-square',
+            this.settings.filter.includes('Done'),
+            this.onFilterButton.bind(this),
+        );
         headerFilterButtons.appendChild(doneFilterButton);
 
         const maxDocuments = MaxShownModelsInput.create(
             this.component,
             this.settings.maxDocuments,
             this.global.settings.defaultMaxShow,
-            this.onMaxDocumentsChange.bind(this));
+            this.onMaxDocumentsChange.bind(this),
+        );
         headerFilterButtons.appendChild(maxDocuments);
 
         const searchBox = SearchInput.create(
             this.component,
             this.onSearch.bind(this),
-            this.settings.searchText);
+            this.settings.searchText,
+        );
         headerFilterButtons.appendChild(searchBox);
     }
 
-    private async addDocumentsToTable(batchSize = this.settings.batchSize, sleepBetweenBatches = this.settings.sleepBetweenBatches): Promise<void> {
+    private async addDocumentsToTable(
+        batchSize = this.settings.batchSize,
+        sleepBetweenBatches = this.settings.sleepBetweenBatches,
+    ): Promise<void> {
         let sleepPromise = Promise.resolve();
         const modelsLength = this.models.length;
         const rows: Row[] = [];
@@ -173,8 +209,7 @@ export default class ProjectBlockRenderComponent extends TableBlockRenderCompone
                 }
             }
 
-            if (row)
-                rows.push(row);
+            if (row) rows.push(row);
 
             if ((i !== 0 && i % batchSize === 0) || i === modelsLength - 1) {
                 await sleepPromise;
@@ -185,7 +220,9 @@ export default class ProjectBlockRenderComponent extends TableBlockRenderCompone
         }
     }
 
-    private async generateTableRow(model: (PrjTaskManagementModel<TaskData | TopicData | ProjectData>)): Promise<Row> {
+    private async generateTableRow(
+        model: PrjTaskManagementModel<TaskData | TopicData | ProjectData>,
+    ): Promise<Row> {
         const rowClassList: string[] = [];
         const rowData: DocumentFragment[] = [];
         const rowUid = this.getUID(model);
@@ -193,12 +230,14 @@ export default class ProjectBlockRenderComponent extends TableBlockRenderCompone
         // Row 0 -- Metadata Link
         const metadataLink = document.createDocumentFragment();
         rowData.push(metadataLink);
+
         GeneralComponents.createMetadataLink(
             metadataLink,
             this.component,
             model.file.path,
             model.data.type,
-            model.getCorospondingSymbol());
+            model.getCorospondingSymbol(),
+        );
 
         // Row 1 -- Trafic Light
         const traficLight = document.createDocumentFragment();
@@ -208,12 +247,14 @@ export default class ProjectBlockRenderComponent extends TableBlockRenderCompone
         // Row 2 -- Title & Description
         const titleAndSummary = document.createDocumentFragment();
         rowData.push(titleAndSummary);
+
         ProjectComponents.createTitle(
             titleAndSummary,
             this.component,
             model.file.path,
-            () => model.data.title ?? "",
-            async (value: string) => model.data.title = value);
+            () => model.data.title ?? '',
+            async (value: string) => (model.data.title = value),
+        );
 
         const lineBreak = document.createElement('br');
         titleAndSummary.appendChild(lineBreak);
@@ -221,46 +262,51 @@ export default class ProjectBlockRenderComponent extends TableBlockRenderCompone
         ProjectComponents.createSummary(
             titleAndSummary,
             this.component,
-            model.data.description ?? "",
-            (value: string) => model.data.description = value);
+            model.data.description ?? '',
+            (value: string) => (model.data.description = value),
+        );
 
         // Row 3 -- Priority
         const priority = document.createDocumentFragment();
         rowData.push(priority);
+
         ProjectComponents.createPriority(
             priority,
             this.component,
-            () => model.data.priority?.toString() ?? "0",
-            async (value: string) => model.data.priority = value as unknown as Priority);
+            () => model.data.priority?.toString() ?? '0',
+            async (value: string) =>
+                (model.data.priority = value as unknown as Priority),
+        );
 
         // Row 4 -- Due Date
         const dueDate = document.createDocumentFragment();
         rowData.push(dueDate);
+
         GeneralComponents.createCellDate(
             dueDate,
             this.component,
-            Lng.gt("Due date"),
+            Lng.gt('Due date'),
             this.global.settings.dateFormat,
-            () => model.data.due ?? "na",
-            async (value: string) => model.data.due = value);
+            () => model.data.due ?? 'na',
+            async (value: string) => (model.data.due = value),
+        );
 
         // Row 5 -- Status
         const status = document.createDocumentFragment();
         rowData.push(status);
+
         ProjectComponents.createStatus(
             status,
             this.component,
-            () => model.data.status ?? "Active",
-            async (value: string) => model.data.status = value as unknown as Status);
+            () => model.data.status ?? 'Active',
+            async (value: string) =>
+                (model.data.status = value as unknown as Status),
+        );
 
         // Row 6 -- Tags
         const tags = document.createDocumentFragment();
         rowData.push(tags);
-        GeneralComponents.createCellTags(
-            tags,
-            this.component,
-            model.getTags());
-
+        GeneralComponents.createCellTags(tags, this.component, model.getTags());
 
         const hide = this.getHideState(model, this.settings.maxDocuments);
 
@@ -268,14 +314,17 @@ export default class ProjectBlockRenderComponent extends TableBlockRenderCompone
             rowUid,
             rowData,
             rowClassList,
-            hidden: hide
+            hidden: hide,
         };
+
         return row;
     }
 
     private async onFilterButton(type: string, status: boolean): Promise<void> {
         if (this.settings.filter.includes(type as FilteredModels)) {
-            this.settings.filter = this.settings.filter.filter(v => v !== type);
+            this.settings.filter = this.settings.filter.filter(
+                (v) => v !== type,
+            );
         } else {
             this.settings.filter.push(type as FilteredModels);
         }
@@ -284,20 +333,24 @@ export default class ProjectBlockRenderComponent extends TableBlockRenderCompone
 
     private async onFilterDebounce(): Promise<void> {
         clearTimeout(this.filterButtonDebounceTimer);
+
         this.filterButtonDebounceTimer = setTimeout(async () => {
             await this.onFilter();
         }, 750);
     }
 
-    private async onMaxDocumentsChange(maxDocuments: number): Promise<undefined> {
+    private async onMaxDocumentsChange(
+        maxDocuments: number,
+    ): Promise<undefined> {
         this.settings.maxDocuments = maxDocuments;
         this.onFilter();
+
         return undefined;
     }
 
     private async onSearch(search: string, key: string): Promise<string> {
-        if (key === "Enter") {
-            if (search !== "") {
+        if (key === 'Enter') {
+            if (search !== '') {
                 this.settings.searchText = search;
                 this.settings.search = Search.parseSearchText(search);
                 this.onFilter();
@@ -306,12 +359,14 @@ export default class ProjectBlockRenderComponent extends TableBlockRenderCompone
                 this.settings.search = undefined;
                 this.onFilter();
             }
-        } else if (key === "Escape") {
+        } else if (key === 'Escape') {
             this.settings.searchText = undefined;
             this.settings.search = undefined;
             this.onFilter();
-            return "";
+
+            return '';
         }
+
         return search;
     }
 
@@ -329,8 +384,9 @@ export default class ProjectBlockRenderComponent extends TableBlockRenderCompone
 
             const rowUid = this.getUID(document);
             let hide = this.getHideState(document, undefined);
+
             if (visibleRows >= this.settings.maxDocuments) {
-                hide = true
+                hide = true;
             }
 
             if (hide) {
@@ -351,11 +407,17 @@ export default class ProjectBlockRenderComponent extends TableBlockRenderCompone
         this.normalizeHeader();
     }
 
-    private getHideState(model: (PrjTaskManagementModel<TaskData | TopicData | ProjectData>), maxVisibleRows: number | undefined): boolean {
+    private getHideState(
+        model: PrjTaskManagementModel<TaskData | TopicData | ProjectData>,
+        maxVisibleRows: number | undefined,
+    ): boolean {
         let searchResult = false;
         let maxRows = false;
 
-        if (!this.settings.filter.includes("Done") && model.data.status === "Done") {
+        if (
+            !this.settings.filter.includes('Done') &&
+            model.data.status === 'Done'
+        ) {
             return true;
         }
 
@@ -369,7 +431,8 @@ export default class ProjectBlockRenderComponent extends TableBlockRenderCompone
             maxRows = rowStats.visibleRows >= maxVisibleRows;
         }
 
-        const hide = this.determineHideState(model) || this.determineTagHideState(model);
+        const hide =
+            this.determineHideState(model) || this.determineTagHideState(model);
 
         if (searchResult && !hide) {
             return false; // Shows the document, if it is not hidden and the search was successful
@@ -382,21 +445,39 @@ export default class ProjectBlockRenderComponent extends TableBlockRenderCompone
         return hide; // Standard-Verhalten
     }
 
-    private determineHideState(model: (PrjTaskManagementModel<TaskData | TopicData | ProjectData>)): boolean {
-        if (this.settings.filter.includes("Topic") && model.data.type === "Topic") {
+    private determineHideState(
+        model: PrjTaskManagementModel<TaskData | TopicData | ProjectData>,
+    ): boolean {
+        if (
+            this.settings.filter.includes('Topic') &&
+            model.data.type === 'Topic'
+        ) {
             return false;
         }
-        if (this.settings.filter.includes("Project") && model.data.type === "Project") {
+
+        if (
+            this.settings.filter.includes('Project') &&
+            model.data.type === 'Project'
+        ) {
             return false;
         }
-        if (this.settings.filter.includes("Task") && model.data.type === "Task") {
+
+        if (
+            this.settings.filter.includes('Task') &&
+            model.data.type === 'Task'
+        ) {
             return false;
         }
+
         return true;
     }
 
-    private determineTagHideState(document: (PrjTaskManagementModel<TaskData | TopicData | ProjectData>)): boolean {
-        return this.settings.reactOnActiveFile ? !Helper.isTagIncluded(this.settings.tags, document.getTags()) : false;
+    private determineTagHideState(
+        document: PrjTaskManagementModel<TaskData | TopicData | ProjectData>,
+    ): boolean {
+        return this.settings.reactOnActiveFile
+            ? !Helper.isTagIncluded(this.settings.tags, document.getTags())
+            : false;
     }
 
     public onActiveFileFilter() {
@@ -410,4 +491,4 @@ export default class ProjectBlockRenderComponent extends TableBlockRenderCompone
  * - `Project` includes all projects.
  * - `Task` includes all tasks.
  */
-type FilteredModels = "Topic" | "Project" | "Task" | "Done";
+type FilteredModels = 'Topic' | 'Project' | 'Task' | 'Done';

--- a/src/libs/BlockRenderComponents/RedrawableBlockRenderComponent.ts
+++ b/src/libs/BlockRenderComponents/RedrawableBlockRenderComponent.ts
@@ -1,4 +1,4 @@
 export default abstract class RedrawableBlockRenderComponent {
-    public abstract build(): Promise<void>
-    public abstract redraw(): Promise<void>
+    public abstract build(): Promise<void>;
+    public abstract redraw(): Promise<void>;
 }

--- a/src/libs/BlockRenderComponents/TableBlockRenderComponent.ts
+++ b/src/libs/BlockRenderComponents/TableBlockRenderComponent.ts
@@ -1,16 +1,19 @@
-import Global from "src/classes/Global";
-import { IProcessorSettings } from "../../interfaces/IProcessorSettings";
-import { Component, setIcon } from "obsidian";
-import Table, { TableHeader } from "../Table";
-import Helper from "../Helper";
-import RedrawableBlockRenderComponent from "./RedrawableBlockRenderComponent";
-import IPrjModel from "src/interfaces/IPrjModel";
-import Lng from "src/classes/Lng";
-import { FileType } from "src/types/PrjTypes";
-import { FileMetadata } from "../MetadataCache";
-import { SearchTermsArray } from "../Search";
+import Global from 'src/classes/Global';
+import { IProcessorSettings } from '../../interfaces/IProcessorSettings';
+import { Component, setIcon } from 'obsidian';
+import Table, { TableHeader } from '../Table';
+import Helper from '../Helper';
+import RedrawableBlockRenderComponent from './RedrawableBlockRenderComponent';
+import IPrjModel from 'src/interfaces/IPrjModel';
+import Lng from 'src/classes/Lng';
+import { FileType } from 'src/types/PrjTypes';
+import { FileMetadata } from '../MetadataCache';
+import { SearchTermsArray } from '../Search';
 
-export default abstract class TableBlockRenderComponent<T extends IPrjModel<unknown>> implements RedrawableBlockRenderComponent {
+export default abstract class TableBlockRenderComponent<
+    T extends IPrjModel<unknown>,
+> implements RedrawableBlockRenderComponent
+{
     //#region General properties
     protected global = Global.getInstance();
     protected globalSettings = Global.getInstance().settings;
@@ -29,7 +32,7 @@ export default abstract class TableBlockRenderComponent<T extends IPrjModel<unkn
     //#endregion
     //#region HTML properties
     protected table: Table;
-    protected tableHeaders: TableHeader[]
+    protected tableHeaders: TableHeader[];
     protected headerContainer: HTMLElement;
     protected tableContainer: HTMLElement;
     //#endregion
@@ -71,13 +74,18 @@ export default abstract class TableBlockRenderComponent<T extends IPrjModel<unkn
         const refreshButton = document.createElement('a');
         blockControle.appendChild(refreshButton);
         refreshButton.classList.add('refresh-button');
-        refreshButton.title = Lng.gt("Refresh");
-        refreshButton.href = "#";
-        setIcon(refreshButton, "refresh-cw");
-        this.component.registerDomEvent(refreshButton, 'click', async (event: MouseEvent) => {
-            event.preventDefault();
-            this.redraw();
-        });
+        refreshButton.title = Lng.gt('Refresh');
+        refreshButton.href = '#';
+        setIcon(refreshButton, 'refresh-cw');
+
+        this.component.registerDomEvent(
+            refreshButton,
+            'click',
+            async (event: MouseEvent) => {
+                event.preventDefault();
+                this.redraw();
+            },
+        );
 
         this.tableContainer = document.createElement('div');
         this.processorSettings.container.appendChild(this.tableContainer);
@@ -89,7 +97,8 @@ export default abstract class TableBlockRenderComponent<T extends IPrjModel<unkn
      * @remarks This methode clears the container and calls the `draw` methode.
      */
     public async redraw(): Promise<void> {
-        this.processorSettings.container.innerHTML = "";
+        this.processorSettings.container.innerHTML = '';
+
         return this.draw();
     }
 
@@ -123,34 +132,38 @@ export default abstract class TableBlockRenderComponent<T extends IPrjModel<unkn
      *   All values that are in the array are shown.
      */
     protected parseSettings(): void {
-        this.processorSettings.options.forEach(option => {
+        this.processorSettings.options.forEach((option) => {
             switch (option.label) {
-                case "tags":
-                    if (option.value === "all") {
+                case 'tags':
+                    if (option.value === 'all') {
                         this.settings.tags = [];
-                    } else if (option.value === "this") {
+                    } else if (option.value === 'this') {
                         const tags = this.processorSettings?.frontmatter?.tags;
+
                         if (Array.isArray(tags)) {
                             this.settings.tags.push(...tags);
                         } else if (tags) {
                             this.settings.tags.push(tags);
                         } else {
-                            this.settings.tags = ["NOTAGSNODATA"];
+                            this.settings.tags = ['NOTAGSNODATA'];
                         }
-                    } else if (option.value === "activeFile") {
+                    } else if (option.value === 'activeFile') {
                         // Register event to update the tags when the active file changes
                         this.component.registerEvent(
-                            this.global.app.workspace.on('active-leaf-change', () => this.onActiveFileChange.bind(this)())
+                            this.global.app.workspace.on(
+                                'active-leaf-change',
+                                () => this.onActiveFileChange.bind(this)(),
+                            ),
                         );
                         this.settings.reactOnActiveFile = true;
                     } else {
                         this.settings.tags = option.value;
                     }
                     break;
-                case "maxDocuments":
+                case 'maxDocuments':
                     this.settings.maxDocuments = option.value;
                     break;
-                case "filter":
+                case 'filter':
                     this.settings.filter = option.value;
                     break;
                 default:
@@ -167,10 +180,15 @@ export default abstract class TableBlockRenderComponent<T extends IPrjModel<unkn
      */
     private onActiveFileChange(): void {
         const activeFile = this.global.app.workspace.getActiveFile();
-        if (activeFile && !activeFile.path.contains("Ressourcen/Panels/")) {
-            this.logger.trace("Active file changed: ", activeFile.path);
-            const tags = this.metadataCache.getEntry(activeFile)?.metadata?.frontmatter?.tags;
+
+        if (activeFile && !activeFile.path.contains('Ressourcen/Panels/')) {
+            this.logger.trace('Active file changed: ', activeFile.path);
+
+            const tags =
+                this.metadataCache.getEntry(activeFile)?.metadata?.frontmatter
+                    ?.tags;
             let newTags: string[] = [];
+
             if (Array.isArray(tags)) {
                 newTags = tags;
             } else if (tags && this) {
@@ -186,8 +204,10 @@ export default abstract class TableBlockRenderComponent<T extends IPrjModel<unkn
                 for (let i = 0; i < sortedTags1.length; i++) {
                     if (sortedTags1[i] !== sortedTags2[i]) return true;
                 }
+
                 return false;
             };
+
             if (areTagsDifferent(newTags, this.settings.tags)) {
                 this.settings.tags = newTags;
                 this.onActiveFileDebounce();
@@ -199,8 +219,9 @@ export default abstract class TableBlockRenderComponent<T extends IPrjModel<unkn
      * Debounces the active file change event and triggers a redraw after a delay.
      */
     private onActiveFileDebounce(): void {
-        this.logger.trace("Active file changed: Debouncing");
+        this.logger.trace('Active file changed: Debouncing');
         clearTimeout(this.activeFileDebounceTimer);
+
         this.activeFileDebounceTimer = setTimeout(async () => {
             this.onActiveFileFilter();
         }, 750);
@@ -215,39 +236,54 @@ export default abstract class TableBlockRenderComponent<T extends IPrjModel<unkn
         return Helper.generateUID(model.file.path);
     }
 
-
     /**
      * Retrieves models based on the specified file types, tags, and model factory.
-     * 
+     *
      * @param types - The file types to filter by.
      * @param tags - The tags to filter by.
      * @param modelFactory - The factory function to create models from file metadata.
      * @returns A promise that resolves to an array of models.
      */
-    protected getModels(types: FileType[], tags: string[], modelFactory: (metadata: FileMetadata) => T | undefined): Promise<T[]> {
+    protected getModels(
+        types: FileType[],
+        tags: string[],
+        modelFactory: (metadata: FileMetadata) => T | undefined,
+    ): Promise<T[]> {
         const templateFolder = this.global.settings.templateFolder;
-        const allDocumentFiles = this.metadataCache.cache.filter(file => {
-            const typeFilter = Helper.isTypeIncluded(types, file.metadata.frontmatter?.type);
-            const thisFileAndTemplateFilter = file.file.path !== this.processorSettings.source &&
+
+        const allDocumentFiles = this.metadataCache.cache.filter((file) => {
+            const typeFilter = Helper.isTypeIncluded(
+                types,
+                file.metadata.frontmatter?.type,
+            );
+
+            const thisFileAndTemplateFilter =
+                file.file.path !== this.processorSettings.source &&
                 !file.file.path.startsWith(templateFolder);
+
             if (tags.length > 0) {
-                const tagFilter = Helper.isTagIncluded(tags, file.metadata.frontmatter?.tags);
+                const tagFilter = Helper.isTagIncluded(
+                    tags,
+                    file.metadata.frontmatter?.tags,
+                );
+
                 return thisFileAndTemplateFilter && typeFilter && tagFilter;
             }
+
             return thisFileAndTemplateFilter && typeFilter;
         });
 
         const models: T[] = [];
+
         for (const file of allDocumentFiles) {
             const model = modelFactory(file);
-            if (model)
-                models.push(model);
+
+            if (model) models.push(model);
         }
 
         return Promise.resolve(models);
     }
 }
-
 
 export type BlockRenderSettings = {
     /**
@@ -256,42 +292,42 @@ export type BlockRenderSettings = {
      * `all` includes all documents regardless of their tags.
      * `this` includes documents that have the same tags as the current document.
      */
-    tags: string[],
+    tags: string[];
 
     /**
      * Whether to react to the active file change event.
      */
-    reactOnActiveFile: boolean,
+    reactOnActiveFile: boolean;
 
     /**
      * Filter for the model types to display.
      * Only the types listed in the array will be shown.
      */
-    filter: unknown[],
+    filter: unknown[];
 
     /**
      * The maximum number of models to show at the same time.
      */
-    maxDocuments: number,
+    maxDocuments: number;
 
     /**
      * Search terms array used to filter the models.
      * If undefined, no search filter is applied.
      */
-    search: SearchTermsArray | undefined,
+    search: SearchTermsArray | undefined;
 
     /**
      * The search text.
      */
-    searchText: string | undefined,
+    searchText: string | undefined;
 
     /**
      * The number of models to process in one batch.
      */
-    batchSize: number,
+    batchSize: number;
 
     /**
      * The time to wait (in milliseconds) between processing batches of models.
      */
-    sleepBetweenBatches: number
+    sleepBetweenBatches: number;
 };

--- a/src/libs/ContextMenus/GetMetadata.ts
+++ b/src/libs/ContextMenus/GetMetadata.ts
@@ -1,10 +1,10 @@
-import { Menu, TAbstractFile, TFile } from "obsidian";
-import Global from "src/classes/Global";
-import Lng from "src/classes/Lng";
-import { DocumentModel } from "src/models/DocumentModel";
-import { FileType } from "src/types/PrjTypes";
-import { FileMetadata } from "../MetadataCache";
-import Helper from "../Helper";
+import { Menu, TAbstractFile, TFile } from 'obsidian';
+import Global from 'src/classes/Global';
+import Lng from 'src/classes/Lng';
+import { DocumentModel } from 'src/models/DocumentModel';
+import { FileType } from 'src/types/PrjTypes';
+import { FileMetadata } from '../MetadataCache';
+import Helper from '../Helper';
 
 export default class GetMetadata {
     static instance: GetMetadata;
@@ -16,7 +16,7 @@ export default class GetMetadata {
     protected bindContextMenu = this.onContextMenu.bind(this);
 
     private constructor() {
-        this.logger.debug("Initializing GetMetadata");
+        this.logger.debug('Initializing GetMetadata');
         this.registerEvents();
         this.registerCommands();
     }
@@ -25,6 +25,7 @@ export default class GetMetadata {
         if (!GetMetadata.instance) {
             GetMetadata.instance = new GetMetadata();
         }
+
         return GetMetadata.instance;
     }
 
@@ -34,10 +35,16 @@ export default class GetMetadata {
     public static deconstructor() {
         if (this.instance && this.instance.eventsRegistered) {
             this.instance.logger.trace("Deconstructing 'GetMetadata' events");
-            this.instance.app.workspace.off('file-menu', this.instance.bindContextMenu);
+
+            this.instance.app.workspace.off(
+                'file-menu',
+                this.instance.bindContextMenu,
+            );
             this.instance.eventsRegistered = false;
         } else {
-            this.instance.logger.trace("No 'GetMetadata' events to deconstruct");
+            this.instance.logger.trace(
+                "No 'GetMetadata' events to deconstruct",
+            );
         }
     }
 
@@ -57,13 +64,14 @@ export default class GetMetadata {
      */
     private registerCommands() {
         this.logger.trace("Registering 'GetMetadata' commands");
+
         this.plugin.addCommand({
-            id: "get-metadata-file",
-            name: Lng.gt("Show Metadata File"),
+            id: 'get-metadata-file',
+            name: Lng.gt('Show Metadata File'),
             callback: () => {
                 GetMetadata.getInstance().invoke();
             },
-        })
+        });
     }
 
     /**
@@ -73,23 +81,25 @@ export default class GetMetadata {
      */
     private onContextMenu(menu: Menu, file: TAbstractFile) {
         // Allow only pdf files
-        if (!(file instanceof TFile) || !file.path.endsWith(".pdf")) {
+        if (!(file instanceof TFile) || !file.path.endsWith('.pdf')) {
             return;
         }
         const metadataFile = this.getCorrespondingMetadataFile(file);
+
         if (!metadataFile) {
             return;
         }
         const document = new DocumentModel(metadataFile.file);
+
         if (metadataFile) {
             menu.addSeparator();
+
             menu.addItem((item) => {
-                item.setTitle(Lng.gt("Show Metadata File"))
+                item.setTitle(Lng.gt('Show Metadata File'))
                     .setIcon(document.getCorospondingSymbol())
                     .onClick(async () => {
                         await Helper.openFile(document.file);
-                    }
-                    );
+                    });
             });
         }
     }
@@ -99,12 +109,24 @@ export default class GetMetadata {
      * @param file The document file
      * @returns The metadata file or undefined if not found
      */
-    private getCorrespondingMetadataFile(file: TFile): FileMetadata | undefined {
-        return this.metadataCache.cache.find(metadata => {
-            const type = metadata.metadata.frontmatter?.type as FileType | undefined | null;
-            const fileLink = metadata.metadata.frontmatter?.file as string | undefined | null;
-            if (type && fileLink && type === "Metadata") {
+    private getCorrespondingMetadataFile(
+        file: TFile,
+    ): FileMetadata | undefined {
+        return this.metadataCache.cache.find((metadata) => {
+            const type = metadata.metadata.frontmatter?.type as
+                | FileType
+                | undefined
+                | null;
+
+            const fileLink = metadata.metadata.frontmatter?.file as
+                | string
+                | undefined
+                | null;
+
+            if (type && fileLink && type === 'Metadata') {
                 return fileLink.contains(file.name);
+            } else {
+                return false;
             }
         });
     }
@@ -115,13 +137,21 @@ export default class GetMetadata {
     public async invoke() {
         const workspace = this.app.workspace;
         const activeFile = workspace.getActiveFile();
-        if (!activeFile || !(activeFile instanceof TFile) || !activeFile.path.endsWith(".pdf")) {
-            this.logger.warn("No active pdf file found.");
+
+        if (
+            !activeFile ||
+            !(activeFile instanceof TFile) ||
+            !activeFile.path.endsWith('.pdf')
+        ) {
+            this.logger.warn('No active pdf file found.');
+
             return;
         }
         const metadataFile = this.getCorrespondingMetadataFile(activeFile);
+
         if (!metadataFile) {
-            this.logger.warn("No metadata file to the active pdf file found.");
+            this.logger.warn('No metadata file to the active pdf file found.');
+
             return;
         }
         const document = new DocumentModel(metadataFile.file);

--- a/src/libs/CustomizableRenderChild.ts
+++ b/src/libs/CustomizableRenderChild.ts
@@ -1,5 +1,5 @@
-import { MarkdownRenderChild } from "obsidian";
-import { ILogger } from "src/interfaces/ILogger";
+import { MarkdownRenderChild } from 'obsidian';
+import { ILogger } from 'src/interfaces/ILogger';
 
 /**
  * Customizable Render Child class.
@@ -23,7 +23,8 @@ export default class CustomizableRenderChild extends MarkdownRenderChild {
         container: HTMLElement,
         onLoad: (() => void) | undefined,
         onUnload: (() => void) | undefined,
-        logger?: ILogger) {
+        logger?: ILogger,
+    ) {
         super(container);
         this.logger = logger ?? undefined;
         this.onLoad = onLoad;
@@ -31,13 +32,13 @@ export default class CustomizableRenderChild extends MarkdownRenderChild {
     }
 
     override onload(): void {
-        this.logger?.trace("On Load");
+        this.logger?.trace('On Load');
         this.onLoad?.();
         super.onload();
     }
 
     override onunload(): void {
-        this.logger?.trace("On Unload");
+        this.logger?.trace('On Unload');
         this.onUnload?.();
         super.onunload();
     }

--- a/src/libs/EditableDataView/Components/BaseComponent.ts
+++ b/src/libs/EditableDataView/Components/BaseComponent.ts
@@ -1,5 +1,5 @@
-import { Component, Platform, setIcon } from "obsidian";
-import Global from "src/classes/Global";
+import { Component, Platform, setIcon } from 'obsidian';
+import Global from 'src/classes/Global';
 
 export default abstract class BaseComponent {
     public get container(): HTMLDivElement {
@@ -14,7 +14,7 @@ export default abstract class BaseComponent {
     protected abstract editabilityEnabled: boolean;
     //#region HTML Elements
     private shippingContainer: HTMLDivElement;
-    /** 
+    /**
      * The container that holds the input elements.
      * @remarks Has the CSS classes `editable-data-view` & `data-input-container`.
      */
@@ -35,25 +35,25 @@ export default abstract class BaseComponent {
      * The `dataInputContainer` is visible and the `presentationContainer` is hidden.
      * Fill the `dataInputContainer` with the input elements.
      */
-    abstract onEnableEditCallback: (() => void);
+    abstract onEnableEditCallback: () => void;
     /**
-     * This callback is called when the user clicks on the `cancel` button or 
+     * This callback is called when the user clicks on the `cancel` button or
      * after the `saveChanges`-methode is clicked.
      * The `dataInputContainer` is hidden and the `presentationContainer` is visible.
      */
-    abstract onDisableEditCallback: (() => void);
+    abstract onDisableEditCallback: () => void;
     /**
      * This callback is called when the user clicks on the `save` button.
      * The `dataInputContainer` is hidden and the `presentationContainer` is visible.
      * The changes should be saved and the `presentationContainer` should be filled with the new data.
      */
-    abstract onSaveCallback: (() => Promise<void>);
+    abstract onSaveCallback: () => Promise<void>;
     /**
      * This callback is called when the user clicks on the `edit` button for the first time.
      * The `dataInputContainer` is visible and the `presentationContainer` is hidden.
      * Fill the `dataInputContainer` with the input elements.
      */
-    abstract onFirstEdit: (() => void);
+    abstract onFirstEdit: () => void;
     /**
      * This callback is called when the component is finalized.
      * The `dataInputContainer` is hidden and the `presentationContainer` is visible.
@@ -61,7 +61,7 @@ export default abstract class BaseComponent {
      * @remarks Don't fill the `dataInputContainer` with the input elements!
      * @remarks The configuration of the component is finished when the `onFinalize`-callback is called.
      */
-    abstract onFinalize: (() => void);
+    abstract onFinalize: () => void;
     //#endregion
 
     constructor(component: Component) {
@@ -75,18 +75,30 @@ export default abstract class BaseComponent {
      * @param editabilityEnabled If `true`, the component will be created to allow editing.
      * @tutorial Run this methode in the `finalize`-methode of the child class before creating your elements.
      */
-    protected createBaseStructure(editabilityEnabled: boolean = this.editabilityEnabled): void {
-
+    protected createBaseStructure(
+        editabilityEnabled: boolean = this.editabilityEnabled,
+    ): void {
         this.presentationContainer = document.createElement('div');
-        this.presentationContainer.classList.add('editable-data-view', 'presentation-container');
+
+        this.presentationContainer.classList.add(
+            'editable-data-view',
+            'presentation-container',
+        );
         this.shippingContainer.appendChild(this.presentationContainer);
-        if (editabilityEnabled && (Platform.isMobile ? Global.getInstance().settings.mobile : true)) {
+
+        if (
+            editabilityEnabled &&
+            (Platform.isMobile ? Global.getInstance().settings.mobile : true)
+        ) {
             this.buttonContainer = document.createElement('div');
-            this.buttonContainer.classList.add('editable-data-view', 'button-container');
+
+            this.buttonContainer.classList.add(
+                'editable-data-view',
+                'button-container',
+            );
             this.createEditButton();
             this.shippingContainer.appendChild(this.buttonContainer);
         }
-
     }
 
     /**
@@ -98,7 +110,10 @@ export default abstract class BaseComponent {
         this.editButton.classList.add('editable-data-view');
         this.editButton.classList.add('button');
         setIcon(this.editButton, 'pen');
-        this.component.registerDomEvent(this.editButton, 'click', () => this.enableEditMode());
+
+        this.component.registerDomEvent(this.editButton, 'click', () =>
+            this.enableEditMode(),
+        );
     }
 
     /**
@@ -106,8 +121,17 @@ export default abstract class BaseComponent {
      */
     private createComponentsForEdit(): void {
         this.dataInputContainer = document.createElement('div');
-        this.dataInputContainer.classList.add('editable-data-view', 'data-input-container', 'hidden');
-        this.shippingContainer.insertBefore(this.dataInputContainer, this.presentationContainer);
+
+        this.dataInputContainer.classList.add(
+            'editable-data-view',
+            'data-input-container',
+            'hidden',
+        );
+
+        this.shippingContainer.insertBefore(
+            this.dataInputContainer,
+            this.presentationContainer,
+        );
 
         this.cancelButton = document.createElement('button');
         this.buttonContainer.insertAfter(this.cancelButton, this.editButton);
@@ -115,7 +139,10 @@ export default abstract class BaseComponent {
         this.cancelButton.classList.add('button');
         this.cancelButton.classList.add('hidden');
         setIcon(this.cancelButton, 'x');
-        this.component.registerDomEvent(this.cancelButton, 'click', () => this.disableEditMode());
+
+        this.component.registerDomEvent(this.cancelButton, 'click', () =>
+            this.disableEditMode(),
+        );
 
         this.saveButton = document.createElement('button');
         this.buttonContainer.insertAfter(this.saveButton, this.cancelButton);
@@ -123,7 +150,10 @@ export default abstract class BaseComponent {
         this.saveButton.classList.add('button');
         this.saveButton.classList.add('hidden');
         setIcon(this.saveButton, 'check');
-        this.component.registerDomEvent(this.saveButton, 'click', () => this.saveChanges());
+
+        this.component.registerDomEvent(this.saveButton, 'click', () =>
+            this.saveChanges(),
+        );
     }
 
     /**
@@ -136,7 +166,7 @@ export default abstract class BaseComponent {
 
     /**
      * This method is called when the user clicks on the `edit` button.
-     * It should switch the component to edit mode and 
+     * It should switch the component to edit mode and
      * create the `save` and `cancel` buttons if not already created.
      * @remarks You can call this methode to simulate a click on the `edit` button.
      */
@@ -146,6 +176,7 @@ export default abstract class BaseComponent {
             this.createComponentsForEdit();
             this.onFirstEdit?.();
         }
+
         // Switch mode to Edit: hide the `edit` button and show the `save` and `cancel` buttons.
         if (this.cancelButton && this.saveButton) {
             this.presentationContainer.classList.add('hidden');
@@ -158,7 +189,7 @@ export default abstract class BaseComponent {
     }
 
     /**
-     * This method is called when the user clicks on the `cancel` button or 
+     * This method is called when the user clicks on the `cancel` button or
      * after the `saveChanges`-methode is clicked.
      * @remarks You can call this methode to simulate a click on the `cancel` button.
      */
@@ -197,6 +228,7 @@ export default abstract class BaseComponent {
      */
     public then(callback: (container: HTMLDivElement) => void): BaseComponent {
         callback(this.shippingContainer);
+
         return this;
     }
 }

--- a/src/libs/EditableDataView/Components/DateComponent.ts
+++ b/src/libs/EditableDataView/Components/DateComponent.ts
@@ -1,5 +1,5 @@
-import { Component } from "obsidian";
-import BaseComponent from "./BaseComponent";
+import { Component } from 'obsidian';
+import BaseComponent from './BaseComponent';
 
 export default class DateComponent extends BaseComponent {
     //#region base properties
@@ -12,7 +12,7 @@ export default class DateComponent extends BaseComponent {
     //#endregion
     //#region extended properties
     private _onPresentation: (value: string) => string;
-    private _onSave: ((value: string) => Promise<void>);
+    private _onSave: (value: string) => Promise<void>;
     private _value: string;
     private _title: string;
     //#endregion
@@ -23,7 +23,7 @@ export default class DateComponent extends BaseComponent {
 
     constructor(component: Component) {
         super(component);
-        this.onFinalize = this.build
+        this.onFinalize = this.build;
         this.onFirstEdit = this.buildInput;
         this.onEnableEditCallback = this.enableEdit;
         this.onSaveCallback = this.save;
@@ -37,6 +37,7 @@ export default class DateComponent extends BaseComponent {
      */
     public enableEditability(): DateComponent {
         this.editabilityEnabled = true;
+
         return this;
     }
 
@@ -47,6 +48,7 @@ export default class DateComponent extends BaseComponent {
      */
     public setValue(value: string): DateComponent {
         this._value = value;
+
         return this;
     }
 
@@ -57,6 +59,7 @@ export default class DateComponent extends BaseComponent {
      */
     public setTitle(title: string): DateComponent {
         this._title = title;
+
         return this;
     }
 
@@ -68,6 +71,7 @@ export default class DateComponent extends BaseComponent {
      */
     public setFormator(formator: (value: string) => string): DateComponent {
         this._onPresentation = formator;
+
         return this;
     }
 
@@ -79,6 +83,7 @@ export default class DateComponent extends BaseComponent {
      */
     public onSave(callback: (value: string) => Promise<void>) {
         this._onSave = callback;
+
         return this;
     }
     //#endregion
@@ -91,7 +96,10 @@ export default class DateComponent extends BaseComponent {
         this.presentationSpan.title = this._title;
         this.presentationSpan.classList.add('editable-data-view');
         this.presentationSpan.classList.add('date-presentation');
-        this.presentationSpan.textContent = this._onPresentation ? this._onPresentation(this._value) : this._value;
+
+        this.presentationSpan.textContent = this._onPresentation
+            ? this._onPresentation(this._value)
+            : this._value;
     }
 
     private buildInput() {
@@ -110,7 +118,9 @@ export default class DateComponent extends BaseComponent {
     }
 
     private disableEdit() {
-        this.presentationSpan.textContent = this._onPresentation ? this._onPresentation(this._value) : this._value;
+        this.presentationSpan.textContent = this._onPresentation
+            ? this._onPresentation(this._value)
+            : this._value;
     }
 
     private async save(): Promise<void> {

--- a/src/libs/EditableDataView/Components/DropdownComponent.ts
+++ b/src/libs/EditableDataView/Components/DropdownComponent.ts
@@ -1,5 +1,5 @@
-import { Component } from "obsidian";
-import BaseComponent from "./BaseComponent";
+import { Component } from 'obsidian';
+import BaseComponent from './BaseComponent';
 
 export default class DropdownComponent extends BaseComponent {
     //#region base properties
@@ -12,13 +12,16 @@ export default class DropdownComponent extends BaseComponent {
     //#endregion
     //#region extended properties
     private _onPresentation: (value: string) => Promise<void> | undefined;
-    private _onSave: ((value: string) => Promise<void>);
+    private _onSave: (value: string) => Promise<void>;
     private _value: string;
-    private _options: { value: string; text: string; }[];
-    private get _selectedOption(): { value: string; text: string; } {
-        const selectedOption = this._options.find(o => o.value === this._value);
-        if (selectedOption)
-            return selectedOption;
+    private _options: { value: string; text: string }[];
+    private get _selectedOption(): { value: string; text: string } {
+        const selectedOption = this._options.find(
+            (o) => o.value === this._value,
+        );
+
+        if (selectedOption) return selectedOption;
+
         return { value: this._value, text: this._value };
     }
     private _title: string;
@@ -30,7 +33,7 @@ export default class DropdownComponent extends BaseComponent {
 
     constructor(component: Component) {
         super(component);
-        this.onFinalize = this.build
+        this.onFinalize = this.build;
         this.onFirstEdit = this.buildInput;
         this.onEnableEditCallback = this.enableEdit;
         this.onSaveCallback = this.save;
@@ -44,6 +47,7 @@ export default class DropdownComponent extends BaseComponent {
      */
     public enableEditability() {
         this.editabilityEnabled = true;
+
         return this;
     }
 
@@ -54,6 +58,7 @@ export default class DropdownComponent extends BaseComponent {
      */
     public setValue(value: string) {
         this._value = value;
+
         return this;
     }
 
@@ -62,8 +67,9 @@ export default class DropdownComponent extends BaseComponent {
      * @param options The options to set.
      * @returns The component itself.
      */
-    public setOptions(options: { value: string, text: string }[]) {
+    public setOptions(options: { value: string; text: string }[]) {
         this._options = options;
+
         return this;
     }
 
@@ -74,6 +80,7 @@ export default class DropdownComponent extends BaseComponent {
      */
     public setTitle(title: string) {
         this._title = title;
+
         return this;
     }
 
@@ -84,9 +91,12 @@ export default class DropdownComponent extends BaseComponent {
      * @remarks - The formator is called when the component change in `not-edit` mode.
      * - `value` is the value of the selected option. (Not the text!)
      */
-    public setFormator(formator: (value: string) => { text: string, html?: DocumentFragment }) {
+    public setFormator(
+        formator: (value: string) => { text: string; html?: DocumentFragment },
+    ) {
         this._onPresentation = async (value: string): Promise<void> => {
             const { text, html } = formator(value);
+
             if (html) {
                 this.presentationSpan.innerHTML = '';
                 this.presentationSpan.appendChild(html);
@@ -94,6 +104,7 @@ export default class DropdownComponent extends BaseComponent {
                 this.presentationSpan.textContent = text;
             }
         };
+
         return this;
     }
 
@@ -106,19 +117,22 @@ export default class DropdownComponent extends BaseComponent {
      */
     public onSave(callback: (value: string) => Promise<void>) {
         this._onSave = callback;
+
         return this;
     }
     //#endregion
 
     private enableOptions() {
-        const optionFound = this._options.find(o => o.value === this._value);
+        const optionFound = this._options.find((o) => o.value === this._value);
+
         if (!optionFound) {
             const optionElement = document.createElement('option');
             optionElement.value = this._value;
             optionElement.textContent = `${this._value} (not in options)`;
             this.select.appendChild(optionElement);
         }
-        this._options.forEach(option => {
+
+        this._options.forEach((option) => {
             const optionElement = document.createElement('option');
             optionElement.value = option.value;
             optionElement.textContent = option.text;

--- a/src/libs/EditableDataView/Components/LinkComponent.ts
+++ b/src/libs/EditableDataView/Components/LinkComponent.ts
@@ -1,5 +1,5 @@
-import { Component } from "obsidian";
-import BaseComponent from "./BaseComponent";
+import { Component } from 'obsidian';
+import BaseComponent from './BaseComponent';
 
 export default class LinkComponent extends BaseComponent {
     //#region base properties
@@ -29,7 +29,7 @@ export default class LinkComponent extends BaseComponent {
 
     constructor(component: Component) {
         super(component);
-        this.onFinalize = this.build
+        this.onFinalize = this.build;
         this.onFirstEdit = this.buildInput;
         this.onEnableEditCallback = this.enableEdit;
         this.onSaveCallback = this.save;
@@ -43,6 +43,7 @@ export default class LinkComponent extends BaseComponent {
      */
     public enableEditability() {
         this.editabilityEnabled = true;
+
         return this;
     }
 
@@ -53,6 +54,7 @@ export default class LinkComponent extends BaseComponent {
      */
     public setValue(value: string) {
         this._value = value;
+
         return this;
     }
 
@@ -63,6 +65,7 @@ export default class LinkComponent extends BaseComponent {
      */
     public setPlaceholder(placeholder: string) {
         this._placeholder = placeholder;
+
         return this;
     }
 
@@ -73,6 +76,7 @@ export default class LinkComponent extends BaseComponent {
      */
     public setSuggestions(suggestions: string[]) {
         this._suggestions = suggestions;
+
         return this;
     }
 
@@ -83,6 +87,7 @@ export default class LinkComponent extends BaseComponent {
      */
     public setTitle(title: string) {
         this._title = title;
+
         return this;
     }
 
@@ -93,6 +98,7 @@ export default class LinkComponent extends BaseComponent {
      */
     public setLinkType(type: 'tag' | 'file' | 'external') {
         this.linkType = type;
+
         return this;
     }
 
@@ -104,6 +110,7 @@ export default class LinkComponent extends BaseComponent {
      */
     public setSuggester(suggester: (value: string) => string[]) {
         this._suggester = suggester;
+
         return this;
     }
 
@@ -113,15 +120,21 @@ export default class LinkComponent extends BaseComponent {
      * @returns The component itself.
      * @remarks The formator is called when the component change in `not-edit` mode.
      */
-    public setFormator(formator: (value: string) => { href: string, text: string, html?: DocumentFragment }) {
+    public setFormator(
+        formator: (value: string) => {
+            href: string;
+            text: string;
+            html?: DocumentFragment;
+        },
+    ) {
         this._onPresentation = async (value: string): Promise<void> => {
             const linkContent = formator(value);
             this.link.href = linkContent.href;
+
             if (linkContent.html) {
                 this.link.innerHTML = '';
                 this.link.appendChild(linkContent.html);
-            }
-            else this.link.textContent = linkContent.text;
+            } else this.link.textContent = linkContent.text;
 
             switch (this.linkType) {
                 case 'tag':
@@ -136,9 +149,15 @@ export default class LinkComponent extends BaseComponent {
 
             if (this.input && this.label) {
                 this.input.value = linkContent.text ? linkContent.text : '';
-                this.label.dataset.value = linkContent.text ? linkContent.text : this._placeholder ? this._placeholder : '';
+
+                this.label.dataset.value = linkContent.text
+                    ? linkContent.text
+                    : this._placeholder
+                      ? this._placeholder
+                      : '';
             }
         };
+
         return this;
     }
 
@@ -150,6 +169,7 @@ export default class LinkComponent extends BaseComponent {
      */
     public onSave(callback: (value: string) => Promise<void>) {
         this._onSave = callback;
+
         return this;
     }
     //#endregion
@@ -157,7 +177,8 @@ export default class LinkComponent extends BaseComponent {
     private setSuggestionsList(suggestions: string[]) {
         if (!this.datalist) return;
         this.datalist.innerHTML = '';
-        suggestions.forEach(suggestion => {
+
+        suggestions.forEach((suggestion) => {
             const option = document.createElement('option');
             option.value = suggestion;
             this.datalist.appendChild(option);
@@ -204,20 +225,38 @@ export default class LinkComponent extends BaseComponent {
         this.input.classList.add('editable-data-view');
         this.input.classList.add('text-input');
         this.input.placeholder = this._placeholder ? this._placeholder : '';
+
         this.component.registerDomEvent(this.input, 'input', () => {
-            this.label.dataset.value = this.input.value ? this.input.value : this._placeholder ? this._placeholder : '';
-            if (this._suggester && this.label.dataset.value !== this._placeholder && this.label.dataset.value !== "")
+            this.label.dataset.value = this.input.value
+                ? this.input.value
+                : this._placeholder
+                  ? this._placeholder
+                  : '';
+
+            if (
+                this._suggester &&
+                this.label.dataset.value !== this._placeholder &&
+                this.label.dataset.value !== ''
+            )
                 this.setSuggestionsList(this._suggester(this.input.value));
         });
-        this.component.registerDomEvent(this.input, 'keydown', (event: KeyboardEvent) => {
-            if (event.key === 'Enter') {
-                this.saveChanges();
-            } else if (event.key === 'Escape') {
-                this.disableEditMode();
-            }
-        });
 
-        if ((this._suggestions && this._suggestions.length > 0) || this._suggester) {
+        this.component.registerDomEvent(
+            this.input,
+            'keydown',
+            (event: KeyboardEvent) => {
+                if (event.key === 'Enter') {
+                    this.saveChanges();
+                } else if (event.key === 'Escape') {
+                    this.disableEditMode();
+                }
+            },
+        );
+
+        if (
+            (this._suggestions && this._suggestions.length > 0) ||
+            this._suggester
+        ) {
             const id = Math.random().toString(36).substring(2, 10);
             this.input.setAttribute('list', id);
             this.datalist = document.createElement('datalist');

--- a/src/libs/EditableDataView/Components/SuggestionComponent.ts
+++ b/src/libs/EditableDataView/Components/SuggestionComponent.ts
@@ -1,4 +1,4 @@
-import { Component, MarkdownRenderChild } from "obsidian";
+import { Component, MarkdownRenderChild } from 'obsidian';
 
 /**
  * A suggestion.
@@ -67,6 +67,7 @@ export default class SuggestionComponent {
      */
     public setSuggestions(suggestions: Suggestions) {
         this._suggestions = suggestions;
+
         return this;
     }
 
@@ -78,20 +79,30 @@ export default class SuggestionComponent {
      */
     public setSuggester(suggester: (value: string) => Suggestions) {
         this._suggester = suggester;
+
         return this;
     }
 
     private setSuggestion() {
-
         let suggestion: Suggestion | undefined;
+
         if (!this._scrollMode) {
             // If the scroll mode is disabled, the first suggestion is shown.
             // The first suggestion is the suggestion that starts with the text in the input element. (case insensitive)
-            suggestion = this._activeSuggestions.filter(suggestion => suggestion.value.toLowerCase().startsWith(this._inputElement.textContent?.toLowerCase() ?? '')).first();
+            suggestion = this._activeSuggestions
+                .filter((suggestion) =>
+                    suggestion.value
+                        .toLowerCase()
+                        .startsWith(
+                            this._inputElement.textContent?.toLowerCase() ?? '',
+                        ),
+                )
+                .first();
             this._suggestionIndex = 0;
         } else {
             // In scroll mode, the suggestion at the index is displayed. This index can be changed beforehand using the arrow buttons.
             const index = this._suggestionIndex;
+
             if (index < 0) {
                 suggestion = this._activeSuggestions.last();
                 this._suggestionIndex = this._activeSuggestions.length - 1;
@@ -105,15 +116,29 @@ export default class SuggestionComponent {
         }
 
         if (suggestion) {
-            if (suggestion.value.toLowerCase().startsWith(this._inputElement.textContent?.toLowerCase() ?? '')) {
+            if (
+                suggestion.value
+                    .toLowerCase()
+                    .startsWith(
+                        this._inputElement.textContent?.toLowerCase() ?? '',
+                    )
+            ) {
                 // If the suggestion starts with the text in the input element, the text in the input element is adopted.
-                const suggestionText = suggestion.value.slice(this.inputTextLength);
+                const suggestionText = suggestion.value.slice(
+                    this.inputTextLength,
+                );
                 this.suggestionsContainer.innerText = suggestionText;
             } else {
                 // If the suggestion does not start with the text in the input element, the text in the input element is replaced with the suggestion.
                 const length = this._inputElement.textContent?.length ?? 1;
-                this._inputElement.textContent = suggestion.value.slice(0, length);
-                this.suggestionsContainer.innerText = suggestion.value.slice(length);
+
+                this._inputElement.textContent = suggestion.value.slice(
+                    0,
+                    length,
+                );
+
+                this.suggestionsContainer.innerText =
+                    suggestion.value.slice(length);
                 this.setInputCursorAbsolutePosition(length);
             }
         }
@@ -129,7 +154,9 @@ export default class SuggestionComponent {
      * Refreshes the active suggestions.
      */
     private refreshActiveSuggestions() {
-        this._activeSuggestions = this._suggester ? this._suggester(this._inputElement.textContent ?? '') : this._suggestions;
+        this._activeSuggestions = this._suggester
+            ? this._suggester(this._inputElement.textContent ?? '')
+            : this._suggestions;
     }
 
     /**
@@ -150,8 +177,17 @@ export default class SuggestionComponent {
 
         this.buildSuggestionsContainer();
 
-        this._suggestorChild.registerDomEvent(this._inputElement, 'input', this.onInput.bind(this));
-        this._suggestorChild.registerDomEvent(this._inputElement, 'keydown', this.onKeydown.bind(this));
+        this._suggestorChild.registerDomEvent(
+            this._inputElement,
+            'input',
+            this.onInput.bind(this),
+        );
+
+        this._suggestorChild.registerDomEvent(
+            this._inputElement,
+            'keydown',
+            this.onKeydown.bind(this),
+        );
     }
 
     /**
@@ -177,12 +213,12 @@ export default class SuggestionComponent {
      * - The 'Ctrl' + 'a' button is used to select the text in the input element.
      */
     private onKeydown(event: KeyboardEvent) {
-
         if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
             // If the 'ArrowUp' or 'ArrowDown' button is pressed, the suggestions are scrolled through.
             event.preventDefault();
 
             this._scrollMode = true;
+
             if (event.key === 'ArrowUp') {
                 this._suggestionIndex++;
             } else if (event.key === 'ArrowDown') {
@@ -202,9 +238,9 @@ export default class SuggestionComponent {
             event.preventDefault();
 
             // If the cursor is at the end of the input element, the first character of the suggestions container is adopted.
-            this.adoptSuggestionCharacter() ?
-                this.setInputCursorAbsolutePosition(this.inputTextLength) :
-                this.setInputCursorRelativePosition(1);
+            this.adoptSuggestionCharacter()
+                ? this.setInputCursorAbsolutePosition(this.inputTextLength)
+                : this.setInputCursorRelativePosition(1);
 
             this.refreshActiveSuggestions();
         } else if (event.key === 'Tab') {
@@ -225,8 +261,18 @@ export default class SuggestionComponent {
      */
     private adoptSuggestion() {
         this._inputElement.textContent += this.suggestionsContainer.innerText;
-        const suggestion = this._activeSuggestions.find(suggestion => suggestion.value.toLowerCase().startsWith(this._inputElement.textContent?.toLowerCase() ?? ''))
-        this._inputElement.textContent = suggestion ? suggestion.value : this._inputElement.textContent;
+
+        const suggestion = this._activeSuggestions.find((suggestion) =>
+            suggestion.value
+                .toLowerCase()
+                .startsWith(
+                    this._inputElement.textContent?.toLowerCase() ?? '',
+                ),
+        );
+
+        this._inputElement.textContent = suggestion
+            ? suggestion.value
+            : this._inputElement.textContent;
         this.suggestionsContainer.innerText = '';
         this.setInputCursorAbsolutePosition('end');
     }
@@ -237,10 +283,15 @@ export default class SuggestionComponent {
      */
     private adoptSuggestionCharacter(): boolean {
         if (this.cursorPosition === this.inputTextLength) {
-            this._inputElement.textContent += this.suggestionsContainer.innerText.slice(0, 1);
-            this.suggestionsContainer.innerText = this.suggestionsContainer.innerText.slice(1);
+            this._inputElement.textContent +=
+                this.suggestionsContainer.innerText.slice(0, 1);
+
+            this.suggestionsContainer.innerText =
+                this.suggestionsContainer.innerText.slice(1);
+
             return true;
         }
+
         return false;
     }
 
@@ -256,10 +307,13 @@ export default class SuggestionComponent {
      */
     private get cursorPosition() {
         const selection = window.getSelection();
+
         if (selection && selection.rangeCount > 0) {
             const currentRange = selection.getRangeAt(0);
+
             return currentRange.endOffset;
         }
+
         return 0;
     }
 
@@ -269,7 +323,9 @@ export default class SuggestionComponent {
      * @remarks The position is clamped to the length of the input element and minimum 0.
      */
     private setInputCursorRelativePosition(relativPosition: number) {
-        this.setInputCursorAbsolutePosition(this.cursorPosition + relativPosition);
+        this.setInputCursorAbsolutePosition(
+            this.cursorPosition + relativPosition,
+        );
     }
 
     /**
@@ -284,8 +340,10 @@ export default class SuggestionComponent {
         const range = document.createRange();
 
         if (selection && selection.rangeCount > 0) {
-
-            const safePosition = Math.max(0, Math.min(position, this._inputElement.textContent?.length ?? 0));
+            const safePosition = Math.max(
+                0,
+                Math.min(position, this._inputElement.textContent?.length ?? 0),
+            );
 
             if (this._inputElement.firstChild) {
                 range.setStart(this._inputElement.firstChild, safePosition);
@@ -308,6 +366,7 @@ export default class SuggestionComponent {
         } else if (position === 'end') {
             position = Number.MAX_SAFE_INTEGER;
         }
+
         return position;
     }
 
@@ -316,7 +375,10 @@ export default class SuggestionComponent {
      * @param startPosition Start position of the selection.
      * @param endPosition End position of the selection.
      */
-    private selectText(startPosition: CursorPosition, endPosition: CursorPosition) {
+    private selectText(
+        startPosition: CursorPosition,
+        endPosition: CursorPosition,
+    ) {
         startPosition = this.getCursorPositionNumber(startPosition);
         endPosition = this.getCursorPositionNumber(endPosition);
 
@@ -324,8 +386,21 @@ export default class SuggestionComponent {
         const range = document.createRange();
 
         if (selection && this._inputElement.firstChild) {
-            const safeStartPosition = Math.max(0, Math.min(startPosition, this._inputElement.textContent?.length ?? 0));
-            const safeEndPosition = Math.max(0, Math.min(endPosition, this._inputElement.textContent?.length ?? 0));
+            const safeStartPosition = Math.max(
+                0,
+                Math.min(
+                    startPosition,
+                    this._inputElement.textContent?.length ?? 0,
+                ),
+            );
+
+            const safeEndPosition = Math.max(
+                0,
+                Math.min(
+                    endPosition,
+                    this._inputElement.textContent?.length ?? 0,
+                ),
+            );
 
             range.setStart(this._inputElement.firstChild, safeStartPosition);
             range.setEnd(this._inputElement.firstChild, safeEndPosition);
@@ -344,13 +419,24 @@ export default class SuggestionComponent {
      */
     private buildSuggestionsContainer() {
         this.suggestionsContainer = document.createElement('span');
-        this.suggestionsContainer.classList.add('editable-data-view', 'suggestions-container');
-        this._inputElement.parentElement?.appendChild(this.suggestionsContainer);
+
+        this.suggestionsContainer.classList.add(
+            'editable-data-view',
+            'suggestions-container',
+        );
+
+        this._inputElement.parentElement?.appendChild(
+            this.suggestionsContainer,
+        );
 
         // On click on the suggestions container, the cursor should be set to the end of the input element.
-        this._suggestorChild?.registerDomEvent(this.suggestionsContainer, 'click', () => {
-            this.setInputCursorAbsolutePosition('end');
-        });
+        this._suggestorChild?.registerDomEvent(
+            this.suggestionsContainer,
+            'click',
+            () => {
+                this.setInputCursorAbsolutePosition('end');
+            },
+        );
     }
 
     /**

--- a/src/libs/EditableDataView/Components/TextComponent.ts
+++ b/src/libs/EditableDataView/Components/TextComponent.ts
@@ -1,8 +1,8 @@
-import { Component, MarkdownRenderer } from "obsidian";
-import BaseComponent from "./BaseComponent";
-import Global from "src/classes/Global";
-import Helper from "src/libs/Helper";
-import SuggestionComponent, { Suggestions } from "./SuggestionComponent";
+import { Component, MarkdownRenderer } from 'obsidian';
+import BaseComponent from './BaseComponent';
+import Global from 'src/classes/Global';
+import Helper from 'src/libs/Helper';
+import SuggestionComponent, { Suggestions } from './SuggestionComponent';
 
 export default class TextComponent extends BaseComponent {
     //#region base properties
@@ -15,7 +15,9 @@ export default class TextComponent extends BaseComponent {
     //#endregion
     //#region extended properties
     private _onPresentation: ((value: string) => Promise<void>) | undefined;
-    private _onMarkdownPresentation: ((value: string) => Promise<void>) | undefined;
+    private _onMarkdownPresentation:
+        | ((value: string) => Promise<void>)
+        | undefined;
     private _onSave: ((value: string) => Promise<void>) | undefined;
     private _suggester: ((value: string) => Suggestions) | undefined;
     private _value: string;
@@ -38,7 +40,7 @@ export default class TextComponent extends BaseComponent {
 
     constructor(component: Component) {
         super(component);
-        this.onFinalize = this.build
+        this.onFinalize = this.build;
         this.onFirstEdit = this.buildInput;
         this.onEnableEditCallback = this.enableEdit;
         this.onSaveCallback = this.save;
@@ -52,6 +54,7 @@ export default class TextComponent extends BaseComponent {
      */
     public enableEditability() {
         this.editabilityEnabled = true;
+
         return this;
     }
 
@@ -62,6 +65,7 @@ export default class TextComponent extends BaseComponent {
      */
     public setValue(value: string) {
         this._value = value;
+
         return this;
     }
 
@@ -72,6 +76,7 @@ export default class TextComponent extends BaseComponent {
      */
     public setPlaceholder(placeholder: string) {
         this._placeholder = placeholder;
+
         return this;
     }
 
@@ -82,6 +87,7 @@ export default class TextComponent extends BaseComponent {
      */
     public setSuggestions(suggestions: Suggestions) {
         this._suggestions = suggestions;
+
         return this;
     }
 
@@ -92,6 +98,7 @@ export default class TextComponent extends BaseComponent {
      */
     public setTitle(title: string) {
         this._title = title;
+
         return this;
     }
 
@@ -103,6 +110,7 @@ export default class TextComponent extends BaseComponent {
      */
     public setSuggester(suggester: (value: string) => Suggestions) {
         this._suggester = suggester;
+
         return this;
     }
 
@@ -116,6 +124,7 @@ export default class TextComponent extends BaseComponent {
         this._onPresentation = async (value: string): Promise<void> => {
             this.presentationSpan.textContent = await formator(this._value);
         };
+
         return this;
     }
 
@@ -126,17 +135,26 @@ export default class TextComponent extends BaseComponent {
      * @remarks The formator is called when the component change in `not-edit` mode.
      * - The custom formator is ignored if this method is called!
      */
-    public setRenderMarkdown(path = "") {
+    public setRenderMarkdown(path = '') {
         this._onMarkdownPresentation = (value: string): Promise<void> => {
             if (Helper.isPossiblyMarkdown(value)) {
                 const app = Global.getInstance().app;
-                return MarkdownRenderer.render(app, value, this.presentationSpan, path, this.component);
+
+                return MarkdownRenderer.render(
+                    app,
+                    value,
+                    this.presentationSpan,
+                    path,
+                    this.component,
+                );
             } else {
-                this.presentationSpan.innerHTML = "";
+                this.presentationSpan.innerHTML = '';
                 this.presentationSpan.textContent = value;
+
                 return Promise.resolve();
             }
-        }
+        };
+
         return this;
     }
 
@@ -148,6 +166,7 @@ export default class TextComponent extends BaseComponent {
      */
     public onSave(callback: (value: string) => Promise<void>) {
         this._onSave = callback;
+
         return this;
     }
     //#endregion
@@ -161,6 +180,7 @@ export default class TextComponent extends BaseComponent {
         this.presentationSpan.title = this._title;
         this.presentationSpan.classList.add('editable-data-view');
         this.presentationSpan.classList.add('text-presentation');
+
         if (this._onMarkdownPresentation) {
             this.presentationSpan.textContent = null;
             this._onMarkdownPresentation(this._value);
@@ -172,21 +192,34 @@ export default class TextComponent extends BaseComponent {
 
         if (this._suggestions || this._suggester) {
             if (!this.suggestionComponent) {
-                this.suggestionComponent = new SuggestionComponent(this.presentationSpan, this.component);
+                this.suggestionComponent = new SuggestionComponent(
+                    this.presentationSpan,
+                    this.component,
+                );
             }
-            this._suggestions ? this.suggestionComponent.setSuggestions(this._suggestions) : void 0;
-            this._suggester ? this.suggestionComponent.setSuggester(this._suggester) : void 0;
+
+            this._suggestions
+                ? this.suggestionComponent.setSuggestions(this._suggestions)
+                : void 0;
+
+            this._suggester
+                ? this.suggestionComponent.setSuggester(this._suggester)
+                : void 0;
         }
     }
 
     private buildInput() {
-        this.component.registerDomEvent(this.presentationSpan, 'keydown', (event: KeyboardEvent) => {
-            if (event.key === 'Enter') {
-                this.saveChanges();
-            } else if (event.key === 'Escape') {
-                this.disableEditMode();
-            }
-        });
+        this.component.registerDomEvent(
+            this.presentationSpan,
+            'keydown',
+            (event: KeyboardEvent) => {
+                if (event.key === 'Enter') {
+                    this.saveChanges();
+                } else if (event.key === 'Escape') {
+                    this.disableEditMode();
+                }
+            },
+        );
     }
 
     private enableEdit() {

--- a/src/libs/EditableDataView/Components/TextareaComponent.ts
+++ b/src/libs/EditableDataView/Components/TextareaComponent.ts
@@ -1,7 +1,7 @@
-import { Component, MarkdownRenderer } from "obsidian";
-import BaseComponent from "./BaseComponent";
-import Global from "src/classes/Global";
-import Helper from "src/libs/Helper";
+import { Component, MarkdownRenderer } from 'obsidian';
+import BaseComponent from './BaseComponent';
+import Global from 'src/classes/Global';
+import Helper from 'src/libs/Helper';
 
 export default class TextareaComponent extends BaseComponent {
     //#region base properties
@@ -14,7 +14,9 @@ export default class TextareaComponent extends BaseComponent {
     //#endregion
     //#region extended properties
     private _onPresentation: ((value: string) => Promise<void>) | undefined;
-    private _onMarkdownPresentation: ((value: string) => Promise<void>) | undefined;
+    private _onMarkdownPresentation:
+        | ((value: string) => Promise<void>)
+        | undefined;
     private _onSave: ((value: string) => Promise<void>) | undefined;
     private _value: string;
     private _placeholder: string;
@@ -26,7 +28,7 @@ export default class TextareaComponent extends BaseComponent {
 
     constructor(component: Component) {
         super(component);
-        this.onFinalize = this.build
+        this.onFinalize = this.build;
         this.onFirstEdit = this.buildInput;
         this.onEnableEditCallback = this.enableEdit;
         this.onSaveCallback = this.save;
@@ -40,6 +42,7 @@ export default class TextareaComponent extends BaseComponent {
      */
     public enableEditability() {
         this.editabilityEnabled = true;
+
         return this;
     }
 
@@ -50,6 +53,7 @@ export default class TextareaComponent extends BaseComponent {
      */
     public setValue(value: string) {
         this._value = value;
+
         return this;
     }
 
@@ -60,6 +64,7 @@ export default class TextareaComponent extends BaseComponent {
      */
     public setPlaceholder(placeholder: string) {
         this._placeholder = placeholder;
+
         return this;
     }
 
@@ -70,6 +75,7 @@ export default class TextareaComponent extends BaseComponent {
      */
     public setTitle(title: string) {
         this._title = title;
+
         return this;
     }
 
@@ -83,6 +89,7 @@ export default class TextareaComponent extends BaseComponent {
         this._onPresentation = async (value: string): Promise<void> => {
             this.presentationSpan.textContent = await formator(this._value);
         };
+
         return this;
     }
 
@@ -93,17 +100,26 @@ export default class TextareaComponent extends BaseComponent {
      * @remarks The formator is called when the component change in `not-edit` mode.
      * - The custom formator is ignored if this method is called!
      */
-    public setRenderMarkdown(path = "") {
+    public setRenderMarkdown(path = '') {
         this._onMarkdownPresentation = (value: string): Promise<void> => {
             if (Helper.isPossiblyMarkdown(value)) {
                 const app = Global.getInstance().app;
-                return MarkdownRenderer.render(app, value, this.presentationSpan, path, this.component);
+
+                return MarkdownRenderer.render(
+                    app,
+                    value,
+                    this.presentationSpan,
+                    path,
+                    this.component,
+                );
             } else {
-                this.presentationSpan.innerHTML = "";
+                this.presentationSpan.innerHTML = '';
                 this.presentationSpan.textContent = value;
+
                 return Promise.resolve();
             }
-        }
+        };
+
         return this;
     }
 
@@ -115,6 +131,7 @@ export default class TextareaComponent extends BaseComponent {
      */
     public onSave(callback: (value: string) => Promise<void>) {
         this._onSave = callback;
+
         return this;
     }
     //#endregion
@@ -128,6 +145,7 @@ export default class TextareaComponent extends BaseComponent {
         this.presentationSpan.title = this._title;
         this.presentationSpan.classList.add('editable-data-view');
         this.presentationSpan.classList.add('textarea-presentation');
+
         if (this._onMarkdownPresentation) {
             this.presentationSpan.textContent = null;
             this._onMarkdownPresentation(this._value);
@@ -139,20 +157,25 @@ export default class TextareaComponent extends BaseComponent {
     }
 
     private buildInput() {
-        this.component.registerDomEvent(this.presentationSpan, 'keydown', (event: KeyboardEvent) => {
-            if (event.key === 'Escape') {
-                this.disableEditMode();
-            } else if (event.key === 'Enter') {
-                event.preventDefault();
-                const selection = window.getSelection();
-                if (selection && selection.rangeCount > 0) {
-                    const range = selection.getRangeAt(0);
-                    range.deleteContents();
-                    range.insertNode(document.createTextNode('\n'));
-                    range.collapse(false);
+        this.component.registerDomEvent(
+            this.presentationSpan,
+            'keydown',
+            (event: KeyboardEvent) => {
+                if (event.key === 'Escape') {
+                    this.disableEditMode();
+                } else if (event.key === 'Enter') {
+                    event.preventDefault();
+                    const selection = window.getSelection();
+
+                    if (selection && selection.rangeCount > 0) {
+                        const range = selection.getRangeAt(0);
+                        range.deleteContents();
+                        range.insertNode(document.createTextNode('\n'));
+                        range.collapse(false);
+                    }
                 }
-            }
-        });
+            },
+        );
     }
 
     private enableEdit() {

--- a/src/libs/EditableDataView/EditableDataView.ts
+++ b/src/libs/EditableDataView/EditableDataView.ts
@@ -1,22 +1,26 @@
-import { Component } from "obsidian";
-import DateComponent from "./Components/DateComponent";
-import DropdownComponent from "./Components/DropdownComponent";
-import LinkComponent from "./Components/LinkComponent";
-import TextComponent from "./Components/TextComponent";
-import TextareaComponent from "./Components/TextareaComponent";
+import { Component } from 'obsidian';
+import DateComponent from './Components/DateComponent';
+import DropdownComponent from './Components/DropdownComponent';
+import LinkComponent from './Components/LinkComponent';
+import TextComponent from './Components/TextComponent';
+import TextareaComponent from './Components/TextareaComponent';
 
 export default class EditableDataView {
     private _container: HTMLElement | DocumentFragment;
     private component: Component;
     private attributesList: Record<string, string> = {};
 
-    constructor(container: HTMLElement | DocumentFragment, component: Component) {
+    constructor(
+        container: HTMLElement | DocumentFragment,
+        component: Component,
+    ) {
         this._container = container;
         this.component = component;
     }
 
-
-    public addText(configure: (component: TextComponent) => void): EditableDataView {
+    public addText(
+        configure: (component: TextComponent) => void,
+    ): EditableDataView {
         const textComponent = new TextComponent(this.component);
         configure(textComponent);
         textComponent.finalize();
@@ -26,7 +30,9 @@ export default class EditableDataView {
         return this;
     }
 
-    public addTextarea(configure: (component: TextareaComponent) => void): EditableDataView {
+    public addTextarea(
+        configure: (component: TextareaComponent) => void,
+    ): EditableDataView {
         const textComponent = new TextareaComponent(this.component);
         configure(textComponent);
         textComponent.finalize();
@@ -36,7 +42,9 @@ export default class EditableDataView {
         return this;
     }
 
-    public addLink(configure: (component: LinkComponent) => void): EditableDataView {
+    public addLink(
+        configure: (component: LinkComponent) => void,
+    ): EditableDataView {
         const linkComponent = new LinkComponent(this.component);
         configure(linkComponent);
         linkComponent.finalize();
@@ -46,7 +54,9 @@ export default class EditableDataView {
         return this;
     }
 
-    public addDate(configure: (component: DateComponent) => void): EditableDataView {
+    public addDate(
+        configure: (component: DateComponent) => void,
+    ): EditableDataView {
         const dateComponent = new DateComponent(this.component);
         configure(dateComponent);
         dateComponent.finalize();
@@ -56,7 +66,9 @@ export default class EditableDataView {
         return this;
     }
 
-    public addDropdown(configure: (component: DropdownComponent) => void): EditableDataView {
+    public addDropdown(
+        configure: (component: DropdownComponent) => void,
+    ): EditableDataView {
         const dropdownComponent = new DropdownComponent(this.component);
         configure(dropdownComponent);
         dropdownComponent.finalize();

--- a/src/libs/FileCache.ts
+++ b/src/libs/FileCache.ts
@@ -1,8 +1,8 @@
 // Note: FileCache class
 
-import Logging from "src/classes/Logging";
-import Global from "../classes/Global";
-import { App, TAbstractFile, TFile } from "obsidian";
+import Logging from 'src/classes/Logging';
+import Global from '../classes/Global';
+import { App, TAbstractFile, TFile } from 'obsidian';
 
 /**
  * FileCache class
@@ -10,7 +10,7 @@ import { App, TAbstractFile, TFile } from "obsidian";
  */
 export default class FileCache {
     private app: App = Global.getInstance().app;
-    private logger = Logging.getLogger("FileCache");
+    private logger = Logging.getLogger('FileCache');
     private fileCachePromise: Promise<void> | null = null;
     private fileCache: Map<string, TFile | null> | null = null;
     private duplicateNames: Map<string, Array<TFile>> | null = null;
@@ -27,6 +27,7 @@ export default class FileCache {
         if (!FileCache.instance) {
             FileCache.instance = new FileCache();
         }
+
         return FileCache.instance;
     }
 
@@ -38,7 +39,7 @@ export default class FileCache {
     constructor() {
         if (!this.fileCache) {
             this.buildFileCache().then(() => {
-                this.logger.debug("File Cache built");
+                this.logger.debug('File Cache built');
             });
         }
         this.createEventHandler = this.createEventHandler.bind(this);
@@ -53,7 +54,8 @@ export default class FileCache {
      */
     static deconstructor() {
         if (!FileCache.instance) {
-            Global.getInstance().logger.error("FileCache instance not loaded");
+            Global.getInstance().logger.error('FileCache instance not loaded');
+
             return;
         }
 
@@ -66,11 +68,12 @@ export default class FileCache {
 
             instance.eventsRegistered = false;
 
-            Global.getInstance().logger.debug("File cache events unregistered");
+            Global.getInstance().logger.debug('File cache events unregistered');
+
             return;
         }
 
-        Global.getInstance().logger.debug("File cache events not registered");
+        Global.getInstance().logger.debug('File cache events not registered');
     }
 
     /**
@@ -87,7 +90,7 @@ export default class FileCache {
      */
     public async waitForCacheReady(): Promise<void> {
         while (!this.fileCacheReady) {
-            await new Promise(resolve => setTimeout(resolve, 5));
+            await new Promise((resolve) => setTimeout(resolve, 5));
         }
     }
 
@@ -109,7 +112,10 @@ export default class FileCache {
         this.fileCacheReady = true;
 
         const endTime = Date.now();
-        this.logger.debug(`File cache for ${allFiles.length} files built in ${endTime - startTime}ms`);
+
+        this.logger.debug(
+            `File cache for ${allFiles.length} files built in ${endTime - startTime}ms`,
+        );
     }
 
     /**
@@ -119,9 +125,14 @@ export default class FileCache {
      * @private
      */
     private addEntry(file: TFile) {
-        if (!this.fileCache) { this.logger.error("File cache not available"); return false; }
+        if (!this.fileCache) {
+            this.logger.error('File cache not available');
+
+            return false;
+        }
         let state = true;
         const existingFile = this.fileCache.get(file.name);
+
         if (existingFile === undefined) {
             this.fileCache.set(file.name, file);
         } else if (existingFile === null) {
@@ -142,14 +153,26 @@ export default class FileCache {
      */
     private addDuplicateEntry(file: Array<TFile>) {
         const fileName = file.first()?.name;
-        if (!fileName) { this.logger.error("File name not available"); return false; }
-        if (!this.duplicateNames) { this.logger.error("Duplicate cache not available"); return false; }
+
+        if (!fileName) {
+            this.logger.error('File name not available');
+
+            return false;
+        }
+
+        if (!this.duplicateNames) {
+            this.logger.error('Duplicate cache not available');
+
+            return false;
+        }
         const duplicateEntry = this.duplicateNames.get(fileName);
+
         if (duplicateEntry) {
-            file.forEach(f => duplicateEntry.push(f));
+            file.forEach((f) => duplicateEntry.push(f));
         } else {
             this.duplicateNames.set(fileName, file);
         }
+
         return true;
     }
 
@@ -161,17 +184,29 @@ export default class FileCache {
      * @private
      */
     private removeDuplicateEntry(file: TFile, oldPath: string | null = null) {
-        if (!this.duplicateNames) { this.logger.error("Duplicate cache not available"); return false; }
+        if (!this.duplicateNames) {
+            this.logger.error('Duplicate cache not available');
+
+            return false;
+        }
         const duplicateEntry = this.duplicateNames.get(file.name);
-        if (!duplicateEntry) { this.logger.error("File ${file.name} not found in duplicate cache"); return false; }
+
+        if (!duplicateEntry) {
+            this.logger.error('File ${file.name} not found in duplicate cache');
+
+            return false;
+        }
         const path = oldPath ?? file.path;
-        const index = duplicateEntry.findIndex(f => f.path === path);
+        const index = duplicateEntry.findIndex((f) => f.path === path);
+
         if (index > -1) {
             duplicateEntry.splice(index, 1);
         } else {
             this.logger.error(`File ${file.name} not found in duplicate cache`);
+
             return false;
         }
+
         return true;
     }
 
@@ -182,17 +217,24 @@ export default class FileCache {
      * @private
      */
     private removeEntry(file: TFile) {
-        if (!this.fileCache) { this.logger.error("File cache not available"); return false; }
+        if (!this.fileCache) {
+            this.logger.error('File cache not available');
+
+            return false;
+        }
         let state = true;
         const existingFile = this.fileCache.get(file.name);
+
         if (existingFile) {
             this.fileCache.delete(file.name);
         } else if (existingFile === undefined) {
             this.logger.warn(`File ${file.name} not found in cache`);
+
             return false;
         } else if (existingFile === null) {
             state &&= this.removeDuplicateEntry(file);
         }
+
         return state;
     }
 
@@ -204,11 +246,21 @@ export default class FileCache {
      * @private
      */
     private renameEntry(file: TFile, oldPath: string) {
-        if (!this.fileCache) { this.logger.error("File cache not available"); return false; }
+        if (!this.fileCache) {
+            this.logger.error('File cache not available');
+
+            return false;
+        }
         const oldFileName = this.getFileNameFromPath(oldPath);
-        if (!oldFileName) { this.logger.error("Old file name not available"); return false; }
+
+        if (!oldFileName) {
+            this.logger.error('Old file name not available');
+
+            return false;
+        }
         const existingFile = this.fileCache.get(oldFileName);
         let state = true;
+
         if (existingFile) {
             this.fileCache.delete(oldFileName);
             state &&= this.addEntry(file);
@@ -219,6 +271,7 @@ export default class FileCache {
             state &&= this.removeDuplicateEntry(file, oldPath);
             state &&= this.addDuplicateEntry([file]);
         }
+
         return state;
     }
 
@@ -229,13 +282,19 @@ export default class FileCache {
      */
     private createEventHandler(file: TAbstractFile) {
         let state = true;
+
         if (file instanceof TFile) {
             state &&= this.addEntry(file);
         }
+
         if (state) {
-            this.logger.debug(`File ${file.name} create in file cache event handler success`);
+            this.logger.debug(
+                `File ${file.name} create in file cache event handler success`,
+            );
         } else {
-            this.logger.error(`Error creating file ${file.name} in file cache event handler`);
+            this.logger.error(
+                `Error creating file ${file.name} in file cache event handler`,
+            );
         }
     }
 
@@ -247,15 +306,26 @@ export default class FileCache {
      */
     private renameEventHandler(file: TAbstractFile, oldPath: string) {
         let state = true;
+
         if (file instanceof TFile) {
             const oldFileName = oldPath.split('/').last();
-            if (!oldFileName) { this.logger.error("Cannot extract old file name from the path"); return; }
+
+            if (!oldFileName) {
+                this.logger.error('Cannot extract old file name from the path');
+
+                return;
+            }
             state &&= this.renameEntry(file, oldFileName);
         }
+
         if (state) {
-            this.logger.debug(`File ${file.name} renamed in file cache event handler success`);
+            this.logger.debug(
+                `File ${file.name} renamed in file cache event handler success`,
+            );
         } else {
-            this.logger.error(`Error renaming file ${file.name} in file cache event handler`);
+            this.logger.error(
+                `Error renaming file ${file.name} in file cache event handler`,
+            );
         }
     }
 
@@ -266,13 +336,19 @@ export default class FileCache {
      */
     private deleteEventHandler(file: TAbstractFile) {
         let state = true;
+
         if (file instanceof TFile) {
             state &&= this.removeEntry(file);
         }
+
         if (state) {
-            this.logger.debug(`File ${file.name} delete in file cache event handler success`);
+            this.logger.debug(
+                `File ${file.name} delete in file cache event handler success`,
+            );
         } else {
-            this.logger.error(`Error deleting file ${file.name} in file cache event handler`);
+            this.logger.error(
+                `Error deleting file ${file.name} in file cache event handler`,
+            );
         }
     }
 
@@ -290,7 +366,7 @@ export default class FileCache {
 
             this.eventsRegistered = true;
 
-            this.logger.debug("File cache events registered");
+            this.logger.debug('File cache events registered');
         }
     }
 
@@ -302,7 +378,13 @@ export default class FileCache {
      */
     private getFileNameFromPath(filePath: string) {
         const oldFileName = filePath.split('/').last();
-        if (!oldFileName) { this.logger.error("Cannot extract old file name from the path"); return; }
+
+        if (!oldFileName) {
+            this.logger.error('Cannot extract old file name from the path');
+
+            return;
+        }
+
         return oldFileName;
     }
 
@@ -315,11 +397,20 @@ export default class FileCache {
      */
     public findFileByName(fileName: string): TFile | Array<TFile> | undefined {
         const foundFile = this.fileCache?.get(fileName);
+
         if (foundFile) {
             return foundFile;
         } else if (foundFile === null) {
             const duplicateEntry = this.duplicateNames?.get(fileName);
-            if (!duplicateEntry) { this.logger.error(`File ${fileName} not found in duplicate cache`); return undefined; }
+
+            if (!duplicateEntry) {
+                this.logger.error(
+                    `File ${fileName} not found in duplicate cache`,
+                );
+
+                return undefined;
+            }
+
             return duplicateEntry;
         } else {
             return undefined;
@@ -336,6 +427,7 @@ export default class FileCache {
     public findFirstFileByName(fileName: string): TFile | undefined {
         // eslint-disable-next-line deprecation/deprecation
         const foundFile = this.findFileByName(fileName);
+
         if (foundFile instanceof Array) {
             return foundFile.first();
         } else {
@@ -352,7 +444,13 @@ export default class FileCache {
      */
     public findFileByPath(filePath: string): TFile | Array<TFile> | undefined {
         const fileName = this.getFileNameFromPath(filePath);
-        if (!fileName) { this.logger.error("File name not available"); return undefined; }
+
+        if (!fileName) {
+            this.logger.error('File name not available');
+
+            return undefined;
+        }
+
         // eslint-disable-next-line deprecation/deprecation
         return this.findFileByName(fileName);
     }
@@ -363,8 +461,13 @@ export default class FileCache {
      * @param sourcePath The original path of the file from which the link originates.
      * @returns The file as `TFile` if found, `undefined` otherwise.
      */
-    public findFileByLinkText(linkText: string, sourcePath = ""): TFile | undefined {
-        return this.app.metadataCache.getFirstLinkpathDest(linkText, sourcePath) ?? undefined;
+    public findFileByLinkText(
+        linkText: string,
+        sourcePath = '',
+    ): TFile | undefined {
+        return (
+            this.app.metadataCache.getFirstLinkpathDest(linkText, sourcePath) ??
+            undefined
+        );
     }
-
 }

--- a/src/libs/GenericEvents.ts
+++ b/src/libs/GenericEvents.ts
@@ -1,4 +1,4 @@
-import { ILogger } from "src/interfaces/ILogger";
+import { ILogger } from 'src/interfaces/ILogger';
 
 /**
  * Interface for the callback.
@@ -23,7 +23,11 @@ export interface IEvent<TData, TReturn = void> {
  */
 type RegisteredEvent<T extends ICallback, K extends keyof T['events']> = {
     eventName: K;
-    callback: (data: T['events'][K]['data']) => T['events'][K] extends IEvent<unknown, infer TReturn> ? TReturn : unknown;
+    callback: (
+        data: T['events'][K]['data'],
+    ) => T['events'][K] extends IEvent<unknown, infer TReturn>
+        ? TReturn
+        : unknown;
 };
 
 /**
@@ -73,7 +77,11 @@ export default class GenericEvents<T extends ICallback> {
      */
     public registerEvent<K extends keyof T['events']>(
         eventName: K,
-        callback: (data: T['events'][K]['data']) => T['events'][K] extends IEvent<unknown, infer TReturn> ? TReturn : unknown
+        callback: (
+            data: T['events'][K]['data'],
+        ) => T['events'][K] extends IEvent<unknown, infer TReturn>
+            ? TReturn
+            : unknown,
     ): void {
         // Add the event to the _events array
         this._events.push({ eventName, callback });
@@ -87,16 +95,26 @@ export default class GenericEvents<T extends ICallback> {
      */
     public deregisterEvent<K extends keyof T['events']>(
         eventName: K,
-        callback: (data: T['events'][K]['data']) => T['events'][K] extends IEvent<unknown, infer TReturn> ? TReturn : unknown
+        callback: (
+            data: T['events'][K]['data'],
+        ) => T['events'][K] extends IEvent<unknown, infer TReturn>
+            ? TReturn
+            : unknown,
     ): void {
         // Delete the event from the _events array
         const initialLength = this._events.length;
-        this._events = this._events.filter(event => event.eventName !== eventName || event.callback !== callback);
+
+        this._events = this._events.filter(
+            (event) =>
+                event.eventName !== eventName || event.callback !== callback,
+        );
         const finalLength = this._events.length;
 
         if (finalLength === initialLength) {
             // No event was removed, log a warning
-            this.logger?.warn(`Event ${eventName.toString()} could not be deregistered`);
+            this.logger?.warn(
+                `Event ${eventName.toString()} could not be deregistered`,
+            );
         } else {
             // Event was removed, log a debug message
             this.logger?.debug(`Event ${eventName.toString()} deregistered`);
@@ -112,11 +130,16 @@ export default class GenericEvents<T extends ICallback> {
     public fireEvent<K extends keyof T['events']>(
         eventName: K,
         eventData: T['events'][K]['data'],
-        callback?: (result: T['events'][K] extends IEvent<unknown, infer TReturn> ? TReturn : unknown) => void
+        callback?: (
+            result: T['events'][K] extends IEvent<unknown, infer TReturn>
+                ? TReturn
+                : unknown,
+        ) => void,
     ): void {
         // Find the event in the _events array and execute the callback
-        this._events.filter(event => event.eventName === eventName)
-            .forEach(event => {
+        this._events
+            .filter((event) => event.eventName === eventName)
+            .forEach((event) => {
                 this._executeEventHandler(event.callback, eventData, callback);
                 this.logger?.debug(`Event ${eventName.toString()} fired`);
             });
@@ -129,21 +152,37 @@ export default class GenericEvents<T extends ICallback> {
      * @param callback The callback to execute when the event handler is executed.
      */
     private async _executeEventHandler<K extends keyof T['events']>(
-        handler: (data: T['events'][K]['data']) => T['events'][K] extends IEvent<unknown, infer TReturn> ? TReturn : unknown,
+        handler: (
+            data: T['events'][K]['data'],
+        ) => T['events'][K] extends IEvent<unknown, infer TReturn>
+            ? TReturn
+            : unknown,
         eventData: T['events'][K]['data'],
-        callback?: (result: T['events'][K] extends IEvent<unknown, infer TReturn> ? TReturn : unknown) => void
+        callback?: (
+            result: T['events'][K] extends IEvent<unknown, infer TReturn>
+                ? TReturn
+                : unknown,
+        ) => void,
     ): Promise<void> {
         try {
             // Execute the handler and call the callback with the result
             const result = await handler(eventData);
-            this.logger?.debug(`Event handler for ${handler.toString()} executed`);
+
+            this.logger?.debug(
+                `Event handler for ${handler.toString()} executed`,
+            );
+
             if (callback) {
                 callback(result);
-                this.logger?.debug(`Callback for ${handler.toString()} executed`);
+
+                this.logger?.debug(
+                    `Callback for ${handler.toString()} executed`,
+                );
             }
         } catch (error) {
-            this.logger?.error(`Error in event handler for ${handler.toString()}: ${error}`);
+            this.logger?.error(
+                `Error in event handler for ${handler.toString()}: ${error}`,
+            );
         }
     }
-
 }

--- a/src/libs/Helper.ts
+++ b/src/libs/Helper.ts
@@ -1,6 +1,6 @@
-import { TFile, moment } from "obsidian";
-import Global from "src/classes/Global";
-import { FileType } from "src/types/PrjTypes";
+import { TFile, moment } from 'obsidian';
+import Global from 'src/classes/Global';
+import { FileType } from 'src/types/PrjTypes';
 
 export default class Helper {
     private static md5 = require('crypto-js/md5');
@@ -9,11 +9,15 @@ export default class Helper {
      * Extracts the date, filename, file extension and display text from a wikilink
      * @param wikilink Wikilink to extract the data from, eg. [[2021.01.01 - file.txt|Display text]]
      * @returns {WikilinkData} Object containing the date, filename, file extension and display text
-     * 
+     *
      */
-    static extractDataFromWikilink(wikilink: string | null | undefined): WikilinkData {
+    static extractDataFromWikilink(
+        wikilink: string | null | undefined,
+    ): WikilinkData {
         if (wikilink && typeof wikilink === 'string') {
-            const dismantledLinkMatch = wikilink.match(/\[\[(.+?)(?:\.(\w+))?(?:\|(.*))?\]\]/);
+            const dismantledLinkMatch = wikilink.match(
+                /\[\[(.+?)(?:\.(\w+))?(?:\|(.*))?\]\]/,
+            );
             let date = undefined;
 
             if (!dismantledLinkMatch) {
@@ -22,24 +26,31 @@ export default class Helper {
                     basename: undefined,
                     extension: undefined,
                     filename: undefined,
-                    displayText: undefined
+                    displayText: undefined,
                 };
             } else {
                 // Expected date format is YYYY.MM.DD
-                const dateMatch = dismantledLinkMatch[1].match(/(\d{4})\.(\d{2})\.(\d{2})/);
+                const dateMatch = dismantledLinkMatch[1].match(
+                    /(\d{4})\.(\d{2})\.(\d{2})/,
+                );
+
                 if (dateMatch) {
-                    date = new Date(`${dateMatch[1]}-${dateMatch[2]}-${dateMatch[3]}`);
+                    date = new Date(
+                        `${dateMatch[1]}-${dateMatch[2]}-${dateMatch[3]}`,
+                    );
                 }
+
                 // If no file extension is given, use "md" as default. Links without a file extension are always markdown files.
                 if (!dismantledLinkMatch[2]) {
-                    dismantledLinkMatch[2] = "md"
+                    dismantledLinkMatch[2] = 'md';
                 }
+
                 return {
                     date: date,
                     basename: dismantledLinkMatch[1],
                     extension: dismantledLinkMatch[2],
                     filename: `${dismantledLinkMatch[1]}.${dismantledLinkMatch[2]}`,
-                    displayText: dismantledLinkMatch[3]
+                    displayText: dismantledLinkMatch[3],
                 };
             }
         } else {
@@ -48,7 +59,7 @@ export default class Helper {
                 basename: undefined,
                 extension: undefined,
                 filename: undefined,
-                displayText: undefined
+                displayText: undefined,
             };
         }
     }
@@ -63,18 +74,22 @@ export default class Helper {
      */
     static generateUID(input: string, length = 8): string {
         const hash = 'U' + this.md5(input).toString();
+
         return hash.substring(0, length);
     }
 
     static formatDate(date: string, format: string): string {
         const regexDate = /^\d{4}-\d{2}-\d{2}$/;
+
         if (!regexDate.test(date)) {
             return date;
         }
         const formatedDate = moment(date).format(format);
+
         if (formatedDate === 'Invalid date') {
             return date;
         }
+
         return formatedDate;
     }
 
@@ -84,7 +99,7 @@ export default class Helper {
      * @returns A promise that resolves after the given amount of milliseconds
      */
     static async sleep(ms: number): Promise<void> {
-        return new Promise(resolve => setTimeout(resolve, ms));
+        return new Promise((resolve) => setTimeout(resolve, ms));
     }
 
     /**
@@ -98,19 +113,21 @@ export default class Helper {
         let regexMarkdownSymbols;
         const regexLineBreak = /\r?\n/;
         const lineBreak = regexLineBreak.test(text);
+
         if (lineBreak) {
             // If there is a line break, we need to check for the list symbol
             regexMarkdownSymbols = /[*_\-[\]=]/;
         } else {
             // If there is no line break, we do not need to check for the list symbol
             regexMarkdownSymbols = /[*_[\]=]/;
-
         }
+
         return regexMarkdownSymbols.test(text);
     }
 
     static containsHTML(text: string) {
         const htmlRegex = /<[^>]*>/;
+
         return htmlRegex.test(text);
     }
 
@@ -120,37 +137,56 @@ export default class Helper {
      * @param tagsToBeChecked The tags to be checked against
      * @returns Whether any tag from `tagsToCheck` is a substring of any tag in `tagsToBeChecked`
      */
-    static isTagIncluded(tagsToCheck: string | string[], tagsToBeChecked: string | string[]): boolean {
-        const _tagsToCheck: string[] = Array.isArray(tagsToCheck) ?
-            tagsToCheck : (tagsToCheck ? [tagsToCheck] : []);
-        const _tagsToBeChecked: string[] = Array.isArray(tagsToBeChecked) ?
-            tagsToBeChecked : (tagsToBeChecked ? [tagsToBeChecked] : []);
+    static isTagIncluded(
+        tagsToCheck: string | string[],
+        tagsToBeChecked: string | string[],
+    ): boolean {
+        const _tagsToCheck: string[] = Array.isArray(tagsToCheck)
+            ? tagsToCheck
+            : tagsToCheck
+              ? [tagsToCheck]
+              : [];
 
-        return _tagsToCheck.some(tagToCheck =>
-            _tagsToBeChecked.some(tagToBeChecked =>
-                tagToBeChecked?.includes(tagToCheck)
-            )
+        const _tagsToBeChecked: string[] = Array.isArray(tagsToBeChecked)
+            ? tagsToBeChecked
+            : tagsToBeChecked
+              ? [tagsToBeChecked]
+              : [];
+
+        return _tagsToCheck.some((tagToCheck) =>
+            _tagsToBeChecked.some((tagToBeChecked) =>
+                tagToBeChecked?.includes(tagToCheck),
+            ),
         );
     }
 
-
     /**
      * Checks if a given file type or an array of file types is included in another given file type or an array of file types.
-     * 
+     *
      * @param typesToCheck The file type or array of file types to check.
      * @param typesToBeChecked The file type or array of file types to be checked against.
      * @returns A boolean indicating whether the file type(s) to be checked are included in the file type(s) to check.
      */
-    static isTypeIncluded(typesToCheck: FileType | FileType[], typesToBeChecked: FileType | FileType[]): boolean {
-        const _typesToCheck: FileType[] = Array.isArray(typesToCheck) ?
-            typesToCheck : (typesToCheck ? [typesToCheck] : []);
-        const _typesToBeChecked: FileType[] = Array.isArray(typesToBeChecked) ?
-            typesToBeChecked : (typesToBeChecked ? [typesToBeChecked] : []);
+    static isTypeIncluded(
+        typesToCheck: FileType | FileType[],
+        typesToBeChecked: FileType | FileType[],
+    ): boolean {
+        const _typesToCheck: FileType[] = Array.isArray(typesToCheck)
+            ? typesToCheck
+            : typesToCheck
+              ? [typesToCheck]
+              : [];
 
-        return _typesToCheck.some(typeToCheck =>
-            _typesToBeChecked.some(typeToBeChecked =>
-                typeToBeChecked === typeToCheck
-            )
+        const _typesToBeChecked: FileType[] = Array.isArray(typesToBeChecked)
+            ? typesToBeChecked
+            : typesToBeChecked
+              ? [typesToBeChecked]
+              : [];
+
+        return _typesToCheck.some((typeToCheck) =>
+            _typesToBeChecked.some(
+                (typeToBeChecked) => typeToBeChecked === typeToCheck,
+            ),
         );
     }
 
@@ -161,14 +197,21 @@ export default class Helper {
      */
     static isPrjTaskManagementFile(file: TFile): boolean {
         const metadata = Global.getInstance().metadataCache.getEntry(file);
+
         if (!metadata) {
             return false;
         }
-        const type = metadata.metadata.frontmatter?.type as FileType | undefined | null;
+
+        const type = metadata.metadata.frontmatter?.type as
+            | FileType
+            | undefined
+            | null;
+
         if (!type) {
             return false;
         }
-        return ["Topic", "Project", "Task"].includes(type);
+
+        return ['Topic', 'Project', 'Task'].includes(type);
     }
 
     /**
@@ -178,6 +221,7 @@ export default class Helper {
      */
     static isEmoji(str: string) {
         const emojiRegex = /(\p{Emoji_Presentation}|\p{Emoji}\uFE0F)/u;
+
         return emojiRegex.test(str);
     }
 
@@ -196,6 +240,7 @@ export default class Helper {
 
         // Determine the prefix based on the input or date
         let prefixValue = '';
+
         if (prefix === 'year') {
             // Extract the last two digits of the current year
             const currentYear: number = new Date().getFullYear();
@@ -210,24 +255,33 @@ export default class Helper {
         }
 
         // Split the text into words and filter out empty words
-        const words: string[] = text.split(' ').filter(word => word.trim().length > 0);
+        const words: string[] = text
+            .split(' ')
+            .filter((word) => word.trim().length > 0);
         let acronym = '';
         // Determine the maximum number of characters per word
         let maxChars: number = Math.floor(length / words.length);
+
         // Ensure at least one character per word
         if (maxChars < 1) maxChars = 1;
+
         // Adjust maxChars if total length is insufficient
         if (maxChars * words.length < length) maxChars++;
 
         // Construct the acronym from the words
         for (let i = 0; i < words.length; i++) {
-            acronym += words[i].substring(0, Math.min(maxChars, words[i].length));
+            acronym += words[i].substring(
+                0,
+                Math.min(maxChars, words[i].length),
+            );
+
             // Stop if desired length is reached
             if (acronym.length >= length) break;
         }
 
         // Limit the acronym to the desired length
         acronym = acronym.substring(0, length);
+
         // Combine the prefix and the acronym
         return prefixValue + acronym;
     }
@@ -235,41 +289,52 @@ export default class Helper {
     static getActiveFile(): TFile | undefined {
         const workspace = Global.getInstance().app.workspace;
         const activeFile = workspace.getActiveFile();
+
         if (!activeFile) {
             return undefined;
         }
+
         return activeFile;
     }
 
     // Generate a random string
     static generateRandomString(length: number): string {
-        const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+        const characters =
+            'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
         let result = '';
+
         for (let i = 0; i < length; i++) {
             const randomIndex = Math.floor(Math.random() * characters.length);
             result += characters.charAt(randomIndex);
         }
+
         return result;
     }
 
     static existTag(tag: string): boolean {
         const metadataCache = Global.getInstance().metadataCache.cache;
+
         const tagFound = metadataCache.find((value) => {
             const tags = value.metadata?.frontmatter?.tags;
+
             if (!tags) {
                 return false;
             }
+
             if (Array.isArray(tags)) {
                 return tags.includes(tag);
             } else {
                 return tags === tag;
             }
         });
+
         return tagFound !== undefined;
     }
 
     static async openFile(file: TFile): Promise<void> {
-        Global.getInstance().logger.trace(`Opening metadata file for ${file.name}`);
+        Global.getInstance().logger.trace(
+            `Opening metadata file for ${file.name}`,
+        );
         const workspace = Global.getInstance().app.workspace;
         const newLeaf = workspace.getLeaf(true);
         await newLeaf.openFile(file);
@@ -280,7 +345,7 @@ export default class Helper {
 
     /**
      * Sanitizes a filename by removing any characters that are not alphanumeric, hyphen, underscore, period, or space.
-     * 
+     *
      * @param filename - The filename to sanitize.
      * @returns The sanitized filename.
      */
@@ -292,11 +357,12 @@ export default class Helper {
         const workspace = Global.getInstance().app.workspace;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any, deprecation/deprecation
         const activeLeaf = workspace.activeLeaf as any;
+
         if (activeLeaf) {
             try {
                 activeLeaf.rebuildView();
-            }
-            catch (error) {
+            } catch (error) {
+                // eslint-disable-next-line no-console
                 console.error(error);
             }
         }
@@ -310,4 +376,3 @@ export type WikilinkData = {
     filename: string | undefined;
     displayText: string | undefined;
 };
-

--- a/src/libs/MarkdownBlockProcessor.ts
+++ b/src/libs/MarkdownBlockProcessor.ts
@@ -1,17 +1,17 @@
 /* eslint-disable no-case-declarations */
 // Note: MarkdownBlockProcessor Class
 
-import { MarkdownPostProcessorContext, MarkdownRenderChild } from "obsidian";
+import { MarkdownPostProcessorContext, MarkdownRenderChild } from 'obsidian';
 import * as yaml from 'js-yaml';
-import Global from "../classes/Global";
-import DocumentBlockRenderComponent from "./BlockRenderComponents/DocumentBlockRenderComponent";
-import { IProcessorSettings } from "../interfaces/IProcessorSettings";
-import ProjectBlockRenderComponent from "./BlockRenderComponents/ProjectBlockRenderComponent";
-import Logging from "src/classes/Logging";
-import Helper from "./Helper";
-import NoteBlockRenderComponent from "./BlockRenderComponents/NoteBlockRenderComponent";
-import SingletonBlockProcessor from "./SingletonBlockProcessor";
-import HeaderBlockRenderComponent from "./BlockRenderComponents/HeaderBlockRenderComponent";
+import Global from '../classes/Global';
+import DocumentBlockRenderComponent from './BlockRenderComponents/DocumentBlockRenderComponent';
+import { IProcessorSettings } from '../interfaces/IProcessorSettings';
+import ProjectBlockRenderComponent from './BlockRenderComponents/ProjectBlockRenderComponent';
+import Logging from 'src/classes/Logging';
+import Helper from './Helper';
+import NoteBlockRenderComponent from './BlockRenderComponents/NoteBlockRenderComponent';
+import SingletonBlockProcessor from './SingletonBlockProcessor';
+import HeaderBlockRenderComponent from './BlockRenderComponents/HeaderBlockRenderComponent';
 
 class MdRenderChild extends MarkdownRenderChild {
     constructor(container: HTMLElement) {
@@ -19,8 +19,8 @@ class MdRenderChild extends MarkdownRenderChild {
     }
 
     override onunload(): void {
-        const logger = Logging.getLogger("MdRenderChild");
-        logger.trace("On Unload");
+        const logger = Logging.getLogger('MdRenderChild');
+        logger.trace('On Unload');
         super.onunload();
     }
 }
@@ -29,22 +29,31 @@ class MdRenderChild extends MarkdownRenderChild {
  * Class for the markdown block processor.
  */
 export default class MarkdownBlockProcessor {
-
-    static async parseSource(source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext) {
+    static async parseSource(
+        source: string,
+        el: HTMLElement,
+        ctx: MarkdownPostProcessorContext,
+    ) {
         const startTime = Date.now();
         const global = Global.getInstance();
         await global.metadataCache.waitForCacheReady();
-        const logger = Logging.getLogger("BlockProcessor");
+        const logger = Logging.getLogger('BlockProcessor');
         logger.trace(`DocId: ${ctx.docId}`);
 
         const uid = Helper.generateUID(source.trim(), 15);
-        const setting: IProcessorSettings = yaml.load(source) as IProcessorSettings;
+
+        const setting: IProcessorSettings = yaml.load(
+            source,
+        ) as IProcessorSettings;
 
         // Remove the cm-embed-block class from the parent element
         // and add the prj-block class.
         // This remove the Block-Hover-Effekt from the block
         // and with CSS we remove the Block-Edit-Button
-        const parent = el.closest('div.cm-preview-code-block.cm-embed-block.markdown-rendered');
+        const parent = el.closest(
+            'div.cm-preview-code-block.cm-embed-block.markdown-rendered',
+        );
+
         if (parent) {
             parent.classList.remove('cm-embed-block');
             parent.addClass('prj-block');
@@ -54,14 +63,19 @@ export default class MarkdownBlockProcessor {
             uid,
             el,
             ctx,
-            Logging.getLogger("SingletonBlockProcessor"));
+            Logging.getLogger('SingletonBlockProcessor'),
+        );
 
         const singleToneBlock = singletonBlockProcessor.singletoneContainer;
         el.append(singleToneBlock);
 
         if (!singletonBlockProcessor.checkForSiblingBlocks()) {
             const endTime = Date.now();
-            logger.debug(`MarkdownBlockProcessor runs for ${endTime - startTime}ms`);
+
+            logger.debug(
+                `MarkdownBlockProcessor runs for ${endTime - startTime}ms`,
+            );
+
             return;
         }
 
@@ -69,8 +83,9 @@ export default class MarkdownBlockProcessor {
         singleToneBlock.append(blockContainer);
         blockContainer.classList.add('prj-block-container');
         blockContainer.lang = global.settings.language;
+
         if (setting.styles) {
-            setting.styles.forEach(style => {
+            setting.styles.forEach((style) => {
                 blockContainer.classList.add(style);
             });
         }
@@ -80,42 +95,50 @@ export default class MarkdownBlockProcessor {
         ctx.addChild(cmp);
 
         setting.source = ctx.sourcePath;
-        setting.frontmatter = global.metadataCache.cache.filter(file => file.file.path === ctx.sourcePath).first()?.metadata.frontmatter;
+
+        setting.frontmatter = global.metadataCache.cache
+            .filter((file) => file.file.path === ctx.sourcePath)
+            .first()?.metadata.frontmatter;
         setting.container = blockContainer;
         setting.ctx = ctx;
 
         if (setting) {
             switch (setting.type) {
-                case "Documents":
-                    const documentBlock = new DocumentBlockRenderComponent(setting);
+                case 'Documents':
+                    const documentBlock = new DocumentBlockRenderComponent(
+                        setting,
+                    );
                     await documentBlock.build();
                     break;
-                case "Tasks":
-                case "Projects":
-                case "Topics":
-                    const projectBlock = new ProjectBlockRenderComponent(setting);
+                case 'Tasks':
+                case 'Projects':
+                case 'Topics':
+                    const projectBlock = new ProjectBlockRenderComponent(
+                        setting,
+                    );
                     await projectBlock.build();
                     break;
-                case "Notes":
+                case 'Notes':
                     const noteBlock = new NoteBlockRenderComponent(setting);
                     await noteBlock.build();
                     break;
-                case "Header":
+                case 'Header':
                     const header = new HeaderBlockRenderComponent(setting);
                     await header.build();
                     break;
-                case "Debug":
-                    console.log("Debug Mode");
-                    console.log(`Settings: ${setting}`);
+                case 'Debug':
+                    logger.debug('Debug Mode');
+                    logger.debug(`Settings: ${setting}`);
                     break;
                 default:
                     break;
             }
 
             const endTime = Date.now();
-            logger.debug(`MarkdownBlockProcessor runs for ${endTime - startTime}ms`);
-        }
 
+            logger.debug(
+                `MarkdownBlockProcessor runs for ${endTime - startTime}ms`,
+            );
+        }
     }
 }
-

--- a/src/libs/MetadataCache.ts
+++ b/src/libs/MetadataCache.ts
@@ -1,10 +1,10 @@
 // Note: MetadataCache class
 
-import Logging from "src/classes/Logging";
-import Global from "../classes/Global";
-import { App, CachedMetadata, TFile } from "obsidian";
-import GenericEvents, { ICallback, IEvent } from "./GenericEvents";
-import PrjTypes from "src/types/PrjTypes";
+import Logging from 'src/classes/Logging';
+import Global from '../classes/Global';
+import { App, CachedMetadata, TFile } from 'obsidian';
+import GenericEvents, { ICallback, IEvent } from './GenericEvents';
+import PrjTypes from 'src/types/PrjTypes';
 
 /**
  * FileMetadata interface
@@ -12,7 +12,10 @@ import PrjTypes from "src/types/PrjTypes";
  * @property {TFile} file The file object
  * @property {CachedMetadata} metadata The cached metadata
  */
-export class FileMetadata { file: TFile; metadata: CachedMetadata }
+export class FileMetadata {
+    file: TFile;
+    metadata: CachedMetadata;
+}
 
 /**
  * Singleton class for caching metadata
@@ -21,7 +24,7 @@ export class FileMetadata { file: TFile; metadata: CachedMetadata }
 export default class MetadataCache {
     private eventHandler: GenericEvents<MetadataCacheEvents>;
     private app: App = Global.getInstance().app;
-    private logger = Logging.getLogger("MetadataCache");
+    private logger = Logging.getLogger('MetadataCache');
     private metadataCachePromise: Promise<void> | undefined = undefined;
     private metadataCache: Map<string, FileMetadata> | undefined = undefined;
     private metadataCacheArray: FileMetadata[] | undefined = undefined;
@@ -40,14 +43,17 @@ export default class MetadataCache {
      */
     public get cache(): FileMetadata[] {
         if (this.metadataCacheReady && this.metadataCache) {
-            if (this.metadataCacheArray)
-                return this.metadataCacheArray;
+            if (this.metadataCacheArray) return this.metadataCacheArray;
             else {
-                this.metadataCacheArray = Array.from(this.metadataCache.values());
+                this.metadataCacheArray = Array.from(
+                    this.metadataCache.values(),
+                );
+
                 return this.metadataCacheArray;
             }
         } else {
-            this.logger.error("Metadata cache not initialized");
+            this.logger.error('Metadata cache not initialized');
+
             return [];
         }
     }
@@ -60,6 +66,7 @@ export default class MetadataCache {
         if (!MetadataCache.instance) {
             MetadataCache.instance = new MetadataCache();
         }
+
         return MetadataCache.instance;
     }
 
@@ -76,7 +83,7 @@ export default class MetadataCache {
 
         if (!this.metadataCache) {
             this.buildMetadataCache().then(() => {
-                this.logger.debug("Metadata cache built");
+                this.logger.debug('Metadata cache built');
                 this.registerEvents();
             });
         }
@@ -88,7 +95,10 @@ export default class MetadataCache {
      */
     static deconstructor() {
         if (!MetadataCache.instance) {
-            Global.getInstance().logger.error("Metadata cache instance not loaded");
+            Global.getInstance().logger.error(
+                'Metadata cache instance not loaded',
+            );
+
             return;
         }
 
@@ -96,16 +106,29 @@ export default class MetadataCache {
 
         if (instance.eventsRegistered) {
             instance.app.vault.off('rename', instance.renameEventHandler);
-            instance.app.metadataCache.off('changed', instance.changedEventHandler);
-            instance.app.metadataCache.off('deleted', instance.deleteEventHandler);
+
+            instance.app.metadataCache.off(
+                'changed',
+                instance.changedEventHandler,
+            );
+
+            instance.app.metadataCache.off(
+                'deleted',
+                instance.deleteEventHandler,
+            );
 
             instance.eventsRegistered = false;
 
-            Global.getInstance().logger.debug("Metadata cache events unregistered");
+            Global.getInstance().logger.debug(
+                'Metadata cache events unregistered',
+            );
+
             return;
         }
 
-        Global.getInstance().logger.debug("Metadata cache events not registered");
+        Global.getInstance().logger.debug(
+            'Metadata cache events not registered',
+        );
     }
 
     /**
@@ -123,7 +146,7 @@ export default class MetadataCache {
      */
     public async waitForCacheReady(): Promise<void> {
         while (!this.metadataCacheReady) {
-            await new Promise(resolve => setTimeout(resolve, 5));
+            await new Promise((resolve) => setTimeout(resolve, 5));
         }
     }
 
@@ -132,21 +155,30 @@ export default class MetadataCache {
      * @param eventName The name of the event: `prj-task-management-changed-status`
      * @param listener The listener function. The listener function receives the file object as an argument.
      */
-    public on(eventName: 'prj-task-management-changed-status', listener: (file: TFile) => void): void;
+    public on(
+        eventName: 'prj-task-management-changed-status',
+        listener: (file: TFile) => void,
+    ): void;
 
     /**
      * Register an event listener for the metadata cache. The event is emitted when the metadata of a document is changed.
      * @param eventName The name of the event: `document-changed-metadata`
      * @param listener The listener function. The listener function receives the file object as an argument.
      */
-    public on(eventName: 'document-changed-metadata', listener: (file: TFile) => void): void;
+    public on(
+        eventName: 'document-changed-metadata',
+        listener: (file: TFile) => void,
+    ): void;
 
     /**
      * Register an event listener for the metadata cache. The event is emitted when the metadata of a plugin file is changed.
      * @param eventName The name of the event: `prj-task-management-file-changed`
      * @param listener The listener function. The listener function receives the file object as an argument.
      */
-    public on(eventName: 'prj-task-management-file-changed', listener: (file: TFile) => void): void;
+    public on(
+        eventName: 'prj-task-management-file-changed',
+        listener: (file: TFile) => void,
+    ): void;
 
     /**
      * Register an event listener for the metadata cache.
@@ -156,21 +188,31 @@ export default class MetadataCache {
     public on<K extends keyof MetadataCacheEvents['events']>(
         eventName: K,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        listener: (file: MetadataCacheEvents['events'][K]['data']) => MetadataCacheEvents['events'][K] extends IEvent<any, infer TReturn> ? TReturn : void
+        listener: (
+            file: MetadataCacheEvents['events'][K]['data'],
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ) => MetadataCacheEvents['events'][K] extends IEvent<any, infer TReturn>
+            ? TReturn
+            : void,
     ): void {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         this.eventHandler.registerEvent(eventName, listener as any);
     }
 
     /**
-     * Deregister an event listener for the metadata cache. 
+     * Deregister an event listener for the metadata cache.
      * @param eventName The name of the event
      * @param listener The listener function.
      */
     public off<K extends keyof MetadataCacheEvents['events']>(
         eventName: K,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        listener: (file: MetadataCacheEvents['events'][K]['data']) => MetadataCacheEvents['events'][K] extends IEvent<any, infer TReturn> ? TReturn : void
+        listener: (
+            file: MetadataCacheEvents['events'][K]['data'],
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ) => MetadataCacheEvents['events'][K] extends IEvent<any, infer TReturn>
+            ? TReturn
+            : void,
     ): void {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         this.eventHandler.deregisterEvent(eventName, listener as any);
@@ -182,27 +224,52 @@ export default class MetadataCache {
      * @param oldMetadata The old metadata
      * @param file The file object
      */
-    private async onChangedMetadata(newMetadata: CachedMetadata, oldMetadata: CachedMetadata, file: TFile) {
-        this.logger.trace(`Metadata changed for file ${file.path} and is processed.`);
+    private async onChangedMetadata(
+        newMetadata: CachedMetadata,
+        oldMetadata: CachedMetadata,
+        file: TFile,
+    ) {
+        this.logger.trace(
+            `Metadata changed for file ${file.path} and is processed.`,
+        );
+
         // Check if the file is plugin file
-        if (newMetadata.frontmatter?.type && PrjTypes.isValidFileType(newMetadata.frontmatter.type)) {
+        if (
+            newMetadata.frontmatter?.type &&
+            PrjTypes.isValidFileType(newMetadata.frontmatter.type)
+        ) {
             switch (newMetadata.frontmatter.type) {
-                case "Topic":
-                case "Project":
-                case "Task":
+                case 'Topic':
+                case 'Project':
+                case 'Task':
                     // Changed status
-                    if (newMetadata.frontmatter?.status !== oldMetadata.frontmatter?.status) {
-                        this.eventHandler.fireEvent('prj-task-management-changed-status', file);
+                    if (
+                        newMetadata.frontmatter?.status !==
+                        oldMetadata.frontmatter?.status
+                    ) {
+                        this.eventHandler.fireEvent(
+                            'prj-task-management-changed-status',
+                            file,
+                        );
                     }
-                    this.eventHandler.fireEvent('prj-task-management-file-changed', file);
+
+                    this.eventHandler.fireEvent(
+                        'prj-task-management-file-changed',
+                        file,
+                    );
                     break;
-                case "Metadata":
-                    this.eventHandler.fireEvent('document-changed-metadata', file);
+                case 'Metadata':
+                    this.eventHandler.fireEvent(
+                        'document-changed-metadata',
+                        file,
+                    );
                     break;
-                case "Note":
+                case 'Note':
                     break;
                 default:
-                    this.logger.error(`Invalid file type ${newMetadata.frontmatter?.type} for file ${file.path}`);
+                    this.logger.error(
+                        `Invalid file type ${newMetadata.frontmatter?.type} for file ${file.path}`,
+                    );
                     break;
             }
         }
@@ -217,7 +284,7 @@ export default class MetadataCache {
             if (this.metadataCache) {
                 this.metadataCacheArray = undefined;
             } else {
-                this.logger.error("Metadata cache not initialized");
+                this.logger.error('Metadata cache not initialized');
             }
         }
     }
@@ -232,14 +299,17 @@ export default class MetadataCache {
         this.metadataCache = new Map<string, FileMetadata>();
         const allFiles = this.app.vault.getFiles();
 
-        const addEntryPromises = allFiles.map(file => this.addEntry(file));
+        const addEntryPromises = allFiles.map((file) => this.addEntry(file));
 
         await Promise.all(addEntryPromises);
 
         this.metadataCacheReady = true;
 
         const endTime = Date.now();
-        this.logger.debug(`Metadata cache for ${allFiles.length} files built in ${endTime - startTime}ms`);
+
+        this.logger.debug(
+            `Metadata cache for ${allFiles.length} files built in ${endTime - startTime}ms`,
+        );
     }
 
     /**
@@ -252,19 +322,26 @@ export default class MetadataCache {
     public getEntry(file: TFile): FileMetadata | undefined {
         if (this.metadataCache) {
             const metadata = this.metadataCache.get(file.path);
+
             if (metadata) {
                 return metadata;
             } else {
                 this.addEntry(file);
                 const metadata = this.metadataCache.get(file.path);
+
                 if (metadata) {
                     return metadata;
                 }
-                this.logger.warn(`No metadata cache entry found for file ${file.path}`);
+
+                this.logger.warn(
+                    `No metadata cache entry found for file ${file.path}`,
+                );
+
                 return undefined;
             }
         } else {
-            this.logger.error("Metadata cache not initialized");
+            this.logger.error('Metadata cache not initialized');
+
             return undefined;
         }
     }
@@ -278,14 +355,19 @@ export default class MetadataCache {
     public getEntryByPath(path: string): FileMetadata | undefined {
         if (this.metadataCache) {
             const metadata = this.metadataCache.get(path);
+
             if (metadata) {
                 return metadata;
             } else {
-                this.logger.warn(`No metadata cache entry found for file ${path}`);
+                this.logger.warn(
+                    `No metadata cache entry found for file ${path}`,
+                );
+
                 return undefined;
             }
         } else {
-            this.logger.error("Metadata cache not initialized");
+            this.logger.error('Metadata cache not initialized');
+
             return undefined;
         }
     }
@@ -297,6 +379,7 @@ export default class MetadataCache {
     private async addEntry(file: TFile) {
         if (this.metadataCache) {
             const metadata = this.app.metadataCache.getFileCache(file);
+
             if (metadata) {
                 this.metadataCache.set(file.path, { file, metadata });
                 this.invalidateMetadataCacheArray();
@@ -304,7 +387,7 @@ export default class MetadataCache {
                 this.logger.warn(`No metadata found for file ${file.path}`);
             }
         } else {
-            this.logger.error("Metadata cache not initialized");
+            this.logger.error('Metadata cache not initialized');
         }
     }
 
@@ -317,7 +400,7 @@ export default class MetadataCache {
             this.metadataCache.delete(file.path);
             this.invalidateMetadataCacheArray();
         } else {
-            this.logger.error("Metadata cache not initialized");
+            this.logger.error('Metadata cache not initialized');
         }
         this.logger.debug(`Metadata cache entry for file ${file.path} deleted`);
     }
@@ -329,18 +412,21 @@ export default class MetadataCache {
     private async updateEntry(file: TFile, cache: CachedMetadata) {
         if (this.metadataCache) {
             const entry = this.metadataCache.get(file.path);
+
             if (entry && cache) {
                 const oldMetadata = entry.metadata;
                 entry.metadata = cache;
                 this.onChangedMetadata(cache, oldMetadata, file);
                 this.invalidateMetadataCacheArray();
             } else if (!entry) {
-                this.logger.warn(`No metadata cache entry found for file ${file.path}`);
+                this.logger.warn(
+                    `No metadata cache entry found for file ${file.path}`,
+                );
             } else {
                 this.logger.warn(`No metadata found for file ${file.path}`);
             }
         } else {
-            this.logger.error("Metadata cache not initialized");
+            this.logger.error('Metadata cache not initialized');
         }
         this.logger.debug(`Metadata cache entry for file ${file.path} updated`);
     }
@@ -356,9 +442,12 @@ export default class MetadataCache {
             this.addEntry(newFile);
             this.invalidateMetadataCacheArray();
         } else {
-            this.logger.error("Metadata cache not initialized");
+            this.logger.error('Metadata cache not initialized');
         }
-        this.logger.debug(`Metadata cache entry for file ${oldPath} renamed to ${newFile.path}`);
+
+        this.logger.debug(
+            `Metadata cache entry for file ${oldPath} renamed to ${newFile.path}`,
+        );
     }
 
     /**
@@ -386,10 +475,21 @@ export default class MetadataCache {
      * @param data Changed complete file content
      * @param cache Cached metadata
      */
-    private changedEventHandler(file: TFile, data: string, cache: CachedMetadata) {
-        this.logger.trace(`File ${file.path} changed. Data-content:`, { data }, "Cache-metadata:", cache);
+    private changedEventHandler(
+        file: TFile,
+        data: string,
+        cache: CachedMetadata,
+    ) {
+        this.logger.trace(
+            `File ${file.path} changed. Data-content:`,
+            { data },
+            'Cache-metadata:',
+            cache,
+        );
+
         if (this.metadataCache) {
             const existingEntry = this.metadataCache.get(file.path);
+
             if (existingEntry) {
                 this.updateEntry(file, cache);
             } else {
@@ -408,19 +508,16 @@ export default class MetadataCache {
      */
     private registerEvents() {
         if (!this.eventsRegistered) {
-
             this.app.vault.on('rename', this.renameEventHandler);
             this.app.metadataCache.on('changed', this.changedEventHandler);
             this.app.metadataCache.on('deleted', this.deleteEventHandler);
 
             this.eventsRegistered = true;
 
-            this.logger.debug("Metadata cache events registered");
+            this.logger.debug('Metadata cache events registered');
         }
     }
-
 }
-
 
 interface MetadataCacheEvents extends ICallback {
     events: {

--- a/src/libs/Modals/AddAnnotationModal.ts
+++ b/src/libs/Modals/AddAnnotationModal.ts
@@ -1,8 +1,8 @@
-import Global from "src/classes/Global";
-import Lng from "src/classes/Lng";
-import { Field, FormConfiguration, IFormResult } from "src/types/ModalFormType";
-import BaseModalForm from "./BaseModalForm";
-import Helper from "../Helper";
+import Global from 'src/classes/Global';
+import Lng from 'src/classes/Lng';
+import { Field, FormConfiguration, IFormResult } from 'src/types/ModalFormType';
+import BaseModalForm from './BaseModalForm';
+import Helper from '../Helper';
 
 /**
  * Modal to create a new metadata file
@@ -24,41 +24,53 @@ export default class AddAnnotationModal extends BaseModalForm {
     public static registerCommand(): void {
         const global = Global.getInstance();
         global.logger.trace("Registering 'AddAnnotationModal' commands");
+
         global.plugin.addCommand({
-            id: "add-annotation-modal",
-            name: `${Lng.gt("Add annotation")}`,
+            id: 'add-annotation-modal',
+            name: `${Lng.gt('Add annotation')}`,
             callback: async () => {
                 const modal = new AddAnnotationModal();
                 const result = await modal.openForm();
+
                 if (result) {
                     await modal.evaluateForm(result);
                 }
             },
-        })
+        });
     }
 
     /**
      * Opens the modal form
      * @returns {Promise<IFormResult | undefined>} Result of the form
      */
-    public async openForm(preset?: Partial<unknown>): Promise<IFormResult | undefined> {
+    public async openForm(
+        preset?: Partial<unknown>,
+    ): Promise<IFormResult | undefined> {
         if (!this.isApiAvailable()) return;
         this.logger.trace("Opening 'CreateNewMetadataModal' form");
 
         const form = this.constructForm();
         const result = await this.getApi().openForm(form);
-        this.logger.trace(`From closes with status '${result.status}' and data:`, result.data);
+
+        this.logger.trace(
+            `From closes with status '${result.status}' and data:`,
+            result.data,
+        );
+
         return result;
     }
 
-
-    public async evaluateForm(result: IFormResult): Promise<string | undefined> {
+    public async evaluateForm(
+        result: IFormResult,
+    ): Promise<string | undefined> {
         if (!this.isApiAvailable()) return;
-        if (result.status !== "ok" || !result.data) return;
 
-        let uidBase = "";
+        if (result.status !== 'ok' || !result.data) return;
+
+        let uidBase = '';
+
         for (const [key, value] of Object.entries(result.data)) {
-            if (value !== "") {
+            if (value !== '') {
                 uidBase += result.data[key] as string;
             }
         }
@@ -91,69 +103,69 @@ export default class AddAnnotationModal extends BaseModalForm {
      */
     protected constructForm(): FormConfiguration {
         const form: FormConfiguration = {
-            title: `${Lng.gt("Add annotation")}`,
-            name: "new metadata file",
-            customClassname: "annotation-form",
-            fields: []
+            title: `${Lng.gt('Add annotation')}`,
+            name: 'new metadata file',
+            customClassname: 'annotation-form',
+            fields: [],
         };
 
         // Prefix
         const prefix: Field = {
-            name: "prefix",
-            label: Lng.gt("Prefix"),
-            description: Lng.gt("Prefix description"),
+            name: 'prefix',
+            label: Lng.gt('Prefix'),
+            description: Lng.gt('Prefix description'),
             isRequired: false,
             input: {
-                type: "textarea"
-            }
+                type: 'textarea',
+            },
         };
         form.fields.push(prefix);
 
         // Citation
         const citation: Field = {
-            name: "citation",
-            label: Lng.gt("Citation"),
-            description: Lng.gt("Citation description"),
+            name: 'citation',
+            label: Lng.gt('Citation'),
+            description: Lng.gt('Citation description'),
             isRequired: false,
             input: {
-                type: "textarea"
-            }
+                type: 'textarea',
+            },
         };
         form.fields.push(citation);
 
         // Postfix
         const postfix: Field = {
-            name: "postfix",
-            label: Lng.gt("Postfix"),
-            description: Lng.gt("Postfix description"),
+            name: 'postfix',
+            label: Lng.gt('Postfix'),
+            description: Lng.gt('Postfix description'),
             isRequired: false,
             input: {
-                type: "textarea"
-            }
+                type: 'textarea',
+            },
         };
         form.fields.push(postfix);
 
         // Place
         const place: Field = {
-            name: "place",
-            label: Lng.gt("Place"),
-            description: Lng.gt("Place description"),
+            name: 'place',
+            label: Lng.gt('Place'),
+            description: Lng.gt('Place description'),
             isRequired: false,
             input: {
-                type: "text"
-            }
+                type: 'text',
+            },
         };
         form.fields.push(place);
 
         // Comment
         const comment: Field = {
-            name: "comment",
-            label: Lng.gt("Comment"),
-            description: Lng.gt("Comment description"),
+            name: 'comment',
+            label: Lng.gt('Comment'),
+            description: Lng.gt('Comment description'),
             isRequired: false,
             input: {
-                type: "textarea"
-            }
+                type: 'textarea',
+            },
         };
         form.fields.push(comment);
 

--- a/src/libs/Modals/BaseModalForm.ts
+++ b/src/libs/Modals/BaseModalForm.ts
@@ -1,13 +1,17 @@
-import { App, TFile } from "obsidian";
-import Global from "src/classes/Global";
-import Logging from "src/classes/Logging";
-import { FormConfiguration, IFormResult, IModalForm } from "src/types/ModalFormType";
+import { App, TFile } from 'obsidian';
+import Global from 'src/classes/Global';
+import Logging from 'src/classes/Logging';
+import {
+    FormConfiguration,
+    IFormResult,
+    IModalForm,
+} from 'src/types/ModalFormType';
 
 export default abstract class BaseModalForm {
     protected app: App = Global.getInstance().app;
     protected settings = Global.getInstance().settings;
     protected global = Global.getInstance();
-    protected logger = Logging.getLogger("BaseModalForm");
+    protected logger = Logging.getLogger('BaseModalForm');
     protected modalFormApi: IModalForm | null | undefined = null;
 
     /**
@@ -15,7 +19,7 @@ export default abstract class BaseModalForm {
      */
     constructor() {
         if (this.modalFormApi === undefined) {
-            this.logger.error("ModalForms API not found");
+            this.logger.error('ModalForms API not found');
         } else {
             this.modalFormApi = this.setApi();
         }
@@ -27,18 +31,22 @@ export default abstract class BaseModalForm {
      * @remarks Log an error if the API is not available
      */
     protected isApiAvailable(): boolean {
-        if (this.modalFormApi === undefined) this.logger.error("ModalForms API not found");
+        if (this.modalFormApi === undefined)
+            this.logger.error('ModalForms API not found');
+
         if (this.modalFormApi === null) {
             this.modalFormApi = this.setApi();
         }
+
         if (this.modalFormApi === null) return false;
+
         return true;
     }
 
     protected getApi(): IModalForm {
         if (this.modalFormApi === undefined || this.modalFormApi === null) {
-            this.logger.error("ModalForms API not found");
-            throw new Error("ModalForms API not found");
+            this.logger.error('ModalForms API not found');
+            throw new Error('ModalForms API not found');
         } else {
             return this.modalFormApi;
         }
@@ -46,17 +54,23 @@ export default abstract class BaseModalForm {
 
     private setApi(): IModalForm | undefined {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const modalFormApi = (this.app as any).plugins.plugins.modalforms.api as IModalForm;
+        const modalFormApi = (this.app as any).plugins.plugins.modalforms
+            .api as IModalForm;
+
         if (!modalFormApi) {
-            this.logger.error("ModalForms API not found");
+            this.logger.error('ModalForms API not found');
+
             return undefined;
         } else {
-            this.logger.trace("ModalForms API found");
+            this.logger.trace('ModalForms API found');
+
             return modalFormApi;
         }
     }
 
-    public abstract evaluateForm(result: IFormResult): Promise<unknown | undefined>
+    public abstract evaluateForm(
+        result: IFormResult,
+    ): Promise<unknown | undefined>;
 
     public abstract openForm(): Promise<IFormResult | undefined>;
 
@@ -64,9 +78,17 @@ export default abstract class BaseModalForm {
 
     public static getTags(activeFile: TFile | undefined): string[] {
         const tags: string[] = [];
+
         if (activeFile) {
-            const cache = Global.getInstance().metadataCache.getEntry(activeFile);
-            if (cache && cache.metadata && cache.metadata.frontmatter && cache.metadata.frontmatter.tags) {
+            const cache =
+                Global.getInstance().metadataCache.getEntry(activeFile);
+
+            if (
+                cache &&
+                cache.metadata &&
+                cache.metadata.frontmatter &&
+                cache.metadata.frontmatter.tags
+            ) {
                 if (Array.isArray(cache.metadata.frontmatter.tags)) {
                     tags.push(...cache.metadata.frontmatter.tags);
                 } else {
@@ -74,6 +96,7 @@ export default abstract class BaseModalForm {
                 }
             }
         }
+
         return tags;
     }
 }

--- a/src/libs/Modals/ChangeStatusModal.ts
+++ b/src/libs/Modals/ChangeStatusModal.ts
@@ -1,18 +1,21 @@
-import { Modal, Setting } from "obsidian";
-import Lng from "src/classes/Lng";
-import { Status } from "src/types/PrjTypes";
-import Helper from "../Helper";
-import { PrjTaskManagementModel } from "src/models/PrjTaskManagementModel";
-import ProjectData from "src/types/ProjectData";
-import TaskData from "src/types/TaskData";
-import TopicData from "src/types/TopicData";
-import Global from "src/classes/Global";
-import API from "src/classes/API";
+import { Modal, Setting } from 'obsidian';
+import Lng from 'src/classes/Lng';
+import { Status } from 'src/types/PrjTypes';
+import Helper from '../Helper';
+import { PrjTaskManagementModel } from 'src/models/PrjTaskManagementModel';
+import ProjectData from 'src/types/ProjectData';
+import TaskData from 'src/types/TaskData';
+import TopicData from 'src/types/TopicData';
+import Global from 'src/classes/Global';
+import API from 'src/classes/API';
 
 export default class ChangeStatusModal extends Modal {
     newStatus: Status;
-    model: (PrjTaskManagementModel<TaskData | TopicData | ProjectData>);
-    onSubmit: (newStatus: Status, file: (PrjTaskManagementModel<TaskData | TopicData | ProjectData>)) => void;
+    model: PrjTaskManagementModel<TaskData | TopicData | ProjectData>;
+    onSubmit: (
+        newStatus: Status,
+        file: PrjTaskManagementModel<TaskData | TopicData | ProjectData>,
+    ) => void;
 
     constructor() {
         super(Global.getInstance().app);
@@ -21,12 +24,16 @@ export default class ChangeStatusModal extends Modal {
     override open() {
         const workspace = this.app.workspace;
         const activeFile = workspace.getActiveFile();
+
         if (!activeFile) {
             return;
         } else if (!Helper.isPrjTaskManagementFile(activeFile)) {
             return;
         }
-        const model = API.prjTaskManagementModel.getCorospondingModel(activeFile);
+
+        const model =
+            API.prjTaskManagementModel.getCorospondingModel(activeFile);
+
         if (!model) {
             return;
         }
@@ -36,30 +43,32 @@ export default class ChangeStatusModal extends Modal {
 
     onOpen() {
         const { contentEl } = this;
-        contentEl.createEl("h2", { text: Lng.gt("Change Status") });
+        contentEl.createEl('h2', { text: Lng.gt('Change Status') });
 
         new Setting(contentEl)
-            .setName(Lng.gt("New Status"))
+            .setName(Lng.gt('New Status'))
             .addDropdown((cb) => {
-                cb.addOption("Active", Lng.gt("StatusActive"));
-                cb.addOption("Waiting", Lng.gt("StatusWaiting"));
-                cb.addOption("Later", Lng.gt("StatusLater"));
-                cb.addOption("Someday", Lng.gt("StatusSomeday"));
-                cb.addOption("Done", Lng.gt("StatusDone"));
-                cb.setValue(this.model.data.status ?? "Active");
+                cb.addOption('Active', Lng.gt('StatusActive'));
+                cb.addOption('Waiting', Lng.gt('StatusWaiting'));
+                cb.addOption('Later', Lng.gt('StatusLater'));
+                cb.addOption('Someday', Lng.gt('StatusSomeday'));
+                cb.addOption('Done', Lng.gt('StatusDone'));
+                cb.setValue(this.model.data.status ?? 'Active');
+
                 cb.onChange((value) => {
                     this.newStatus = value as Status;
                 });
             });
 
-        new Setting(contentEl)
-            .addButton((btn) =>
-                btn.setButtonText(Lng.gt("Change Status"))
-                    .setCta()
-                    .onClick(() => {
-                        this.close();
-                        this.model.changeStatus(this.newStatus);
-                    }));
+        new Setting(contentEl).addButton((btn) =>
+            btn
+                .setButtonText(Lng.gt('Change Status'))
+                .setCta()
+                .onClick(() => {
+                    this.close();
+                    this.model.changeStatus(this.newStatus);
+                }),
+        );
     }
 
     onClose() {
@@ -74,10 +83,11 @@ export default class ChangeStatusModal extends Modal {
     public static registerCommand(): void {
         const global = Global.getInstance();
         global.logger.trace("Registering 'CreateNewMetadataModal' commands");
+
         global.plugin.addCommand({
-            id: "change-prj-status",
-            name: Lng.gt("Change Status"),
-            callback: () => new ChangeStatusModal().open()
+            id: 'change-prj-status',
+            name: Lng.gt('Change Status'),
+            callback: () => new ChangeStatusModal().open(),
         });
     }
 }

--- a/src/libs/Modals/CreateNewMetadataModal.ts
+++ b/src/libs/Modals/CreateNewMetadataModal.ts
@@ -1,14 +1,19 @@
-import path from "path";
-import Global from "src/classes/Global";
-import Lng from "src/classes/Lng";
-import { DocumentModel } from "src/models/DocumentModel";
-import DocumentData from "src/types/DocumentData";
-import { Field, FormConfiguration, IFormResult, IResultData } from "src/types/ModalFormType";
-import BaseModalForm from "./BaseModalForm";
-import Helper from "../Helper";
-import PrjTypes, { FileSubType } from "src/types/PrjTypes";
-import API from "src/classes/API";
-import { TFile } from "obsidian";
+import path from 'path';
+import Global from 'src/classes/Global';
+import Lng from 'src/classes/Lng';
+import { DocumentModel } from 'src/models/DocumentModel';
+import DocumentData from 'src/types/DocumentData';
+import {
+    Field,
+    FormConfiguration,
+    IFormResult,
+    IResultData,
+} from 'src/types/ModalFormType';
+import BaseModalForm from './BaseModalForm';
+import Helper from '../Helper';
+import PrjTypes, { FileSubType } from 'src/types/PrjTypes';
+import API from 'src/classes/API';
+import { TFile } from 'obsidian';
 
 /**
  * Modal to create a new metadata file
@@ -30,19 +35,21 @@ export default class CreateNewMetadataModal extends BaseModalForm {
     public static registerCommand(): void {
         const global = Global.getInstance();
         global.logger.trace("Registering 'CreateNewMetadataModal' commands");
+
         global.plugin.addCommand({
-            id: "create-new-metadata-file",
-            name: `${Lng.gt("Create new metadata")}`,
+            id: 'create-new-metadata-file',
+            name: `${Lng.gt('Create new metadata')}`,
             callback: async () => {
                 const modal = new CreateNewMetadataModal();
                 const result = await modal.openForm();
+
                 if (result) {
                     const document = await modal.evaluateForm(result);
-                    if (document)
-                        await Helper.openFile(document.file);
+
+                    if (document) await Helper.openFile(document.file);
                 }
             },
-        })
+        });
     }
 
     /**
@@ -50,17 +57,21 @@ export default class CreateNewMetadataModal extends BaseModalForm {
      * @param {Partial<DocumentData>} [preset] Preset values for the form
      * @returns {Promise<IFormResult | undefined>} Result of the form
      */
-    public async openForm(preset?: Partial<DocumentData>): Promise<IFormResult | undefined> {
+    public async openForm(
+        preset?: Partial<DocumentData>,
+    ): Promise<IFormResult | undefined> {
         if (!this.isApiAvailable()) return;
         this.logger.trace("Opening 'CreateNewMetadataModal' form");
         const convertedPreset: IResultData = {};
+
         if (preset) {
             for (const [key, value] of Object.entries(preset)) {
-                convertedPreset[key] = value ?? "";
+                convertedPreset[key] = value ?? '';
             }
         }
         const activeFile = Helper.getActiveFile();
         const tags: string[] = BaseModalForm.getTags(activeFile);
+
         if (convertedPreset) {
             if (convertedPreset.tags && Array.isArray(convertedPreset.tags)) {
                 convertedPreset.tags = [...convertedPreset.tags, ...tags];
@@ -70,8 +81,16 @@ export default class CreateNewMetadataModal extends BaseModalForm {
         }
 
         const form = this.constructForm();
-        const result = await this.getApi().openForm(form, { values: convertedPreset });
-        this.logger.trace(`From closes with status '${result.status}' and data:`, result.data);
+
+        const result = await this.getApi().openForm(form, {
+            values: convertedPreset,
+        });
+
+        this.logger.trace(
+            `From closes with status '${result.status}' and data:`,
+            result.data,
+        );
+
         return result;
     }
 
@@ -83,35 +102,63 @@ export default class CreateNewMetadataModal extends BaseModalForm {
      * 2. Sets the data of the document model to the form result.
      * 3. Creates a new file with the metadata filename or uses the existing file and rename it.
      */
-    public async evaluateForm(result: IFormResult, existingFile?: TFile): Promise<DocumentModel | undefined> {
+    public async evaluateForm(
+        result: IFormResult,
+        existingFile?: TFile,
+    ): Promise<DocumentModel | undefined> {
         if (!this.isApiAvailable()) return;
-        if (result.status !== "ok" || !result.data) return;
 
-        const document = new DocumentModel(existingFile ? existingFile : undefined);
+        if (result.status !== 'ok' || !result.data) return;
 
-        const folder = existingFile?.parent?.path ? existingFile.parent?.path : this.settings.documentSettings.defaultFolder;
+        const document = new DocumentModel(
+            existingFile ? existingFile : undefined,
+        );
 
-        (result.data.subType as FileSubType | undefined) = PrjTypes.isValidFileSubType(result.data.subType);
-        const linkedFile = this.fileCache.findFileByLinkText(result.data.file as string, "");
-        (result.data.file as string | undefined) = result.data.file ? document.setLinkedFile(linkedFile, folder) : undefined;
+        const folder = existingFile?.parent?.path
+            ? existingFile.parent?.path
+            : this.settings.documentSettings.defaultFolder;
+
+        (result.data.subType as FileSubType | undefined) =
+            PrjTypes.isValidFileSubType(result.data.subType);
+
+        const linkedFile = this.fileCache.findFileByLinkText(
+            result.data.file as string,
+            '',
+        );
+
+        (result.data.file as string | undefined) = result.data.file
+            ? document.setLinkedFile(linkedFile, folder)
+            : undefined;
 
         document.data = result.data as Partial<DocumentData>;
 
         if (!existingFile) {
             // No existing file, create a new one
-            let template = "";
+            let template = '';
+
             // If a template is set, use it
-            const templateFile = this.app.vault.getAbstractFileByPath(this.settings.documentSettings.template);
+            const templateFile = this.app.vault.getAbstractFileByPath(
+                this.settings.documentSettings.template,
+            );
+
             if (templateFile && templateFile instanceof TFile) {
                 try {
                     template = await this.app.vault.read(templateFile);
                 } catch (error) {
-                    this.logger.error(`Error reading template file '${templateFile.path}'`, error);
+                    this.logger.error(
+                        `Error reading template file '${templateFile.path}'`,
+                        error,
+                    );
                 }
             }
 
-            const newFileName = API.documentModel.generateMetadataFilename(document);
-            const file = await this.app.vault.create(path.join(folder, `${newFileName}.md`), template);
+            const newFileName =
+                API.documentModel.generateMetadataFilename(document);
+
+            const file = await this.app.vault.create(
+                path.join(folder, `${newFileName}.md`),
+                template,
+            );
             document.file = file;
         } else {
             // Existing file, rename it properly
@@ -127,137 +174,137 @@ export default class CreateNewMetadataModal extends BaseModalForm {
      */
     protected constructForm(): FormConfiguration {
         const form: FormConfiguration = {
-            title: `${Lng.gt("Create new metadata")}`,
-            name: "new metadata file",
-            customClassname: "",
-            fields: []
+            title: `${Lng.gt('Create new metadata')}`,
+            name: 'new metadata file',
+            customClassname: '',
+            fields: [],
         };
 
         // Sub type
         const subType: Field = {
-            name: "subType",
-            label: Lng.gt("Metadata sub type"),
-            description: Lng.gt("Metadata sub type description"),
+            name: 'subType',
+            label: Lng.gt('Metadata sub type'),
+            description: Lng.gt('Metadata sub type description'),
             isRequired: true,
             input: {
-                type: "select",
-                source: "fixed",
+                type: 'select',
+                source: 'fixed',
                 options: [
-                    { value: "none", label: Lng.gt("None") },
-                    { value: "Cluster", label: Lng.gt("Metadata Cluster") }
-                ]
-            }
+                    { value: 'none', label: Lng.gt('None') },
+                    { value: 'Cluster', label: Lng.gt('Metadata Cluster') },
+                ],
+            },
         };
         form.fields.push(subType);
 
         // Date
         const date: Field = {
-            name: "date",
-            label: Lng.gt("Document date"),
-            description: Lng.gt("Document date description"),
+            name: 'date',
+            label: Lng.gt('Document date'),
+            description: Lng.gt('Document date description'),
             isRequired: false,
             input: {
-                type: "date"
-            }
+                type: 'date',
+            },
         };
         form.fields.push(date);
 
         // Date of delivery
         const dateOfDelivery: Field = {
-            name: "dateOfDelivery",
-            label: Lng.gt("Date of delivery"),
-            description: Lng.gt("Date of delivery description"),
+            name: 'dateOfDelivery',
+            label: Lng.gt('Date of delivery'),
+            description: Lng.gt('Date of delivery description'),
             isRequired: false,
             input: {
-                type: "date"
-            }
+                type: 'date',
+            },
         };
         form.fields.push(dateOfDelivery);
 
         // Title
         const title: Field = {
-            name: "title",
-            label: Lng.gt("Title"),
-            description: Lng.gt("Title description"),
+            name: 'title',
+            label: Lng.gt('Title'),
+            description: Lng.gt('Title description'),
             isRequired: true,
             input: {
-                type: "text"
-            }
+                type: 'text',
+            },
         };
         form.fields.push(title);
 
         // Description
         const description: Field = {
-            name: "description",
-            label: Lng.gt("Document description"),
-            description: Lng.gt("Document description description"),
+            name: 'description',
+            label: Lng.gt('Document description'),
+            description: Lng.gt('Document description description'),
             isRequired: false,
             input: {
-                type: "textarea"
-            }
+                type: 'textarea',
+            },
         };
         form.fields.push(description);
 
         // Sender
         const sender: Field = {
-            name: "sender",
-            label: Lng.gt("Sender"),
-            description: Lng.gt("Sender description"),
+            name: 'sender',
+            label: Lng.gt('Sender'),
+            description: Lng.gt('Sender description'),
             isRequired: false,
             input: {
-                type: "dataview",
-                query: "app.plugins.plugins.prj.api.documentModel.getAllSenderRecipients()"
-            }
+                type: 'dataview',
+                query: 'app.plugins.plugins.prj.api.documentModel.getAllSenderRecipients()',
+            },
         };
         form.fields.push(sender);
 
         // Recipient
         const recipient: Field = {
-            name: "recipient",
-            label: Lng.gt("Recipient"),
-            description: Lng.gt("Recipient description"),
+            name: 'recipient',
+            label: Lng.gt('Recipient'),
+            description: Lng.gt('Recipient description'),
             isRequired: false,
             input: {
-                type: "dataview",
-                query: "app.plugins.plugins.prj.api.documentModel.getAllSenderRecipients()"
-            }
+                type: 'dataview',
+                query: 'app.plugins.plugins.prj.api.documentModel.getAllSenderRecipients()',
+            },
         };
         form.fields.push(recipient);
 
         // Hide
         const hide: Field = {
-            name: "hide",
-            label: Lng.gt("Hide"),
-            description: Lng.gt("Hide description"),
+            name: 'hide',
+            label: Lng.gt('Hide'),
+            description: Lng.gt('Hide description'),
             isRequired: false,
             input: {
-                type: "toggle"
-            }
+                type: 'toggle',
+            },
         };
         form.fields.push(hide);
 
         // Tags
         const tags: Field = {
-            name: "tags",
-            label: Lng.gt("Tags"),
-            description: Lng.gt("Tags description"),
+            name: 'tags',
+            label: Lng.gt('Tags'),
+            description: Lng.gt('Tags description'),
             isRequired: false,
             input: {
-                type: "tag"
-            }
+                type: 'tag',
+            },
         };
         form.fields.push(tags);
 
         // File
         const file: Field = {
-            name: "file",
-            label: Lng.gt("PDF file"),
-            description: Lng.gt("PDF file description"),
+            name: 'file',
+            label: Lng.gt('PDF file'),
+            description: Lng.gt('PDF file description'),
             isRequired: false,
             input: {
-                type: "dataview",
-                query: "app.plugins.plugins.prj.api.documentModel.getAllPDFsWithoutMetadata().map(file => file.name)"
-            }
+                type: 'dataview',
+                query: 'app.plugins.plugins.prj.api.documentModel.getAllPDFsWithoutMetadata().map(file => file.name)',
+            },
         };
         form.fields.push(file);
 

--- a/src/libs/Modals/CreateNewTaskManagementModal.ts
+++ b/src/libs/Modals/CreateNewTaskManagementModal.ts
@@ -1,15 +1,15 @@
-import { IFormResult, FormConfiguration, Field } from "src/types/ModalFormType";
-import BaseModalForm from "./BaseModalForm";
-import Lng from "src/classes/Lng";
-import Helper from "../Helper";
-import Global from "src/classes/Global";
-import PrjTypes, { } from "src/types/PrjTypes";
-import { TFile } from "obsidian";
-import path from "path";
-import { PrjTaskManagementModel } from "src/models/PrjTaskManagementModel";
-import ProjectData from "src/types/ProjectData";
-import TaskData from "src/types/TaskData";
-import TopicData from "src/types/TopicData";
+import { IFormResult, FormConfiguration, Field } from 'src/types/ModalFormType';
+import BaseModalForm from './BaseModalForm';
+import Lng from 'src/classes/Lng';
+import Helper from '../Helper';
+import Global from 'src/classes/Global';
+import PrjTypes from 'src/types/PrjTypes';
+import { TFile } from 'obsidian';
+import path from 'path';
+import { PrjTaskManagementModel } from 'src/models/PrjTaskManagementModel';
+import ProjectData from 'src/types/ProjectData';
+import TaskData from 'src/types/TaskData';
+import TopicData from 'src/types/TopicData';
 
 export default class CreateNewTaskManagementModal extends BaseModalForm {
     constructor() {
@@ -25,50 +25,95 @@ export default class CreateNewTaskManagementModal extends BaseModalForm {
         const tags: string[] = BaseModalForm.getTags(activeFile);
 
         const form = this.constructForm();
-        const result = await this.getApi().openForm(form, { values: { tags: tags } });
 
-        this.logger.trace(`From closes with status '${result.status}' and data:`, result.data);
+        const result = await this.getApi().openForm(form, {
+            values: { tags: tags },
+        });
+
+        this.logger.trace(
+            `From closes with status '${result.status}' and data:`,
+            result.data,
+        );
 
         return result;
     }
 
-    public async evaluateForm(result: IFormResult): Promise<(PrjTaskManagementModel<TaskData | TopicData | ProjectData>) | undefined> {
-        if (result.status !== "ok" || !result.data) return;
+    public async evaluateForm(
+        result: IFormResult,
+    ): Promise<
+        PrjTaskManagementModel<TaskData | TopicData | ProjectData> | undefined
+    > {
+        if (result.status !== 'ok' || !result.data) return;
 
-        (result.data.title ?? (() => { this.logger.error("No title provided"); return; })());
-        (result.data.tags ?? (() => { this.logger.error("No tags provided"); return; })());
+        result.data.title ??
+            (() => {
+                this.logger.error('No title provided');
 
-        let model: (PrjTaskManagementModel<TaskData | TopicData | ProjectData>);
-        let modelFolderPath = "";
+                return;
+            })();
+
+        result.data.tags ??
+            (() => {
+                this.logger.error('No tags provided');
+
+                return;
+            })();
+
+        let model: PrjTaskManagementModel<TaskData | TopicData | ProjectData>;
+        let modelFolderPath = '';
         let templateFilePath: string | undefined;
         let subTemplatePath: string | undefined;
         let acronym: string | undefined;
 
         switch (result.data.type) {
-            case "Topic":
-                model = new PrjTaskManagementModel<TopicData>(undefined, TopicData);
-                templateFilePath = this.global.settings.prjSettings.topicTemplate;
+            case 'Topic':
+                model = new PrjTaskManagementModel<TopicData>(
+                    undefined,
+                    TopicData,
+                );
+
+                templateFilePath =
+                    this.global.settings.prjSettings.topicTemplate;
                 modelFolderPath = this.global.settings.prjSettings.topicFolder;
                 acronym = Helper.generateAcronym(result.data.title as string);
                 break;
-            case "Project":
-                model = new PrjTaskManagementModel<ProjectData>(undefined, ProjectData);
-                templateFilePath = this.global.settings.prjSettings.projectTemplate;
-                modelFolderPath = this.global.settings.prjSettings.projectFolder;
+            case 'Project':
+                model = new PrjTaskManagementModel<ProjectData>(
+                    undefined,
+                    ProjectData,
+                );
+
+                templateFilePath =
+                    this.global.settings.prjSettings.projectTemplate;
+
+                modelFolderPath =
+                    this.global.settings.prjSettings.projectFolder;
                 acronym = Helper.generateAcronym(result.data.title as string);
                 break;
-            case "Task":
-                model = new PrjTaskManagementModel<TaskData>(undefined, TaskData);
-                templateFilePath = this.global.settings.prjSettings.taskTemplate;
+            case 'Task':
+                model = new PrjTaskManagementModel<TaskData>(
+                    undefined,
+                    TaskData,
+                );
+
+                templateFilePath =
+                    this.global.settings.prjSettings.taskTemplate;
                 modelFolderPath = this.global.settings.prjSettings.taskFolder;
-                acronym = Helper.generateAcronym(result.data.title as string, 3, "t");
-                if (result.data.subtype && result.data.subtype !== "") {
+
+                acronym = Helper.generateAcronym(
+                    result.data.title as string,
+                    3,
+                    't',
+                );
+
+                if (result.data.subtype && result.data.subtype !== '') {
                     subTemplatePath = result.data.subtype as string;
                 }
                 delete result.data.subtype;
                 break;
             default:
-                this.logger.error("No valid type provided");
+                this.logger.error('No valid type provided');
+
                 return;
         }
 
@@ -76,85 +121,125 @@ export default class CreateNewTaskManagementModal extends BaseModalForm {
             tag: undefined as string | undefined,
             postfix: undefined as number | undefined,
             get fullTag() {
-                return this.tag + (this.postfix ? this.postfix : "");
-            }
+                return this.tag + (this.postfix ? this.postfix : '');
+            },
         };
         const baseTag = this.settings.baseTag;
+
         result.data.tags = (result.data.tags as string[]).map((tag, index) => {
             if (index === 0) {
                 if (tag.startsWith(baseTag)) {
-                    mainTag.tag = `${tag}` + (acronym ? `/${acronym}` : "");
+                    mainTag.tag = `${tag}` + (acronym ? `/${acronym}` : '');
                 } else {
-                    mainTag.tag = `${baseTag}/${tag}` + (acronym ? `/${acronym}` : "");
+                    mainTag.tag =
+                        `${baseTag}/${tag}` + (acronym ? `/${acronym}` : '');
                 }
+
                 while (acronym && Helper.existTag(mainTag.fullTag)) {
-                    if (!mainTag.postfix) { mainTag.postfix = 0; }
+                    if (!mainTag.postfix) {
+                        mainTag.postfix = 0;
+                    }
                     mainTag.postfix++;
                     this.logger.warn(`Tag '${mainTag.fullTag}' already exists`);
                 }
+
                 return mainTag.fullTag;
             }
+
             return tag;
         });
 
-        (mainTag.tag ?? (() => { this.logger.error("No main tag provided"); return; })());
+        mainTag.tag ??
+            (() => {
+                this.logger.error('No main tag provided');
+
+                return;
+            })();
 
         model.data.title = result.data.title as string;
-        model.data.description = result.data.description as string ?? undefined;
+
+        model.data.description =
+            (result.data.description as string) ?? undefined;
         model.changeStatus(result.data.status);
         model.data.priority = PrjTypes.isValidPriority(result.data.priority);
         model.data.energy = PrjTypes.isValidEnergy(result.data.energy);
-        model.data.due = result.data.dueDate as string ?? undefined;
+        model.data.due = (result.data.dueDate as string) ?? undefined;
 
         model.data.tags = result.data.tags as string[];
-        if (result.data.type !== "Task")
+
+        if (result.data.type !== 'Task')
             model.data.aliases = [`#${mainTag.fullTag}`];
 
         const modelFile = {
             filepath: `${modelFolderPath}`,
-            filename: acronym ? `${acronym} - ${result.data.title}` : `${result.data.title}`,
+            filename: acronym
+                ? `${acronym} - ${result.data.title}`
+                : `${result.data.title}`,
             postfix: undefined as number | undefined,
             extension: `.md`,
             file: undefined as TFile | undefined,
             get fullPath() {
-                return path.join(this.filepath, this.filename + (this.postfix ? this.postfix : "") + this.extension);
-            }
+                return path.join(
+                    this.filepath,
+                    this.filename +
+                        (this.postfix ? this.postfix : '') +
+                        this.extension,
+                );
+            },
         };
         modelFile.filename = Helper.sanitizeFilename(modelFile.filename);
 
         /**
          * Check if file already exists and add postfix if needed.
          */
-        modelFile.file = this.app.vault.getAbstractFileByPath(modelFile.fullPath) as TFile;
+        modelFile.file = this.app.vault.getAbstractFileByPath(
+            modelFile.fullPath,
+        ) as TFile;
+
         if (modelFile.file) {
             modelFile.postfix = 0;
+
             while (modelFile.file) {
                 this.logger.warn(`File '${modelFile.fullPath}' already exists`);
                 modelFile.postfix++;
-                modelFile.file = this.app.vault.getAbstractFileByPath(modelFile.fullPath) as TFile;
+
+                modelFile.file = this.app.vault.getAbstractFileByPath(
+                    modelFile.fullPath,
+                ) as TFile;
             }
         }
 
         /**
          * If a template is provided, use it to create the file.
          */
-        let template = "";
+        let template = '';
+
         if (subTemplatePath) {
-            const subTemplateFile = this.app.vault.getAbstractFileByPath(subTemplatePath);
+            const subTemplateFile =
+                this.app.vault.getAbstractFileByPath(subTemplatePath);
+
             if (subTemplateFile && subTemplateFile instanceof TFile) {
                 try {
                     template = await this.app.vault.read(subTemplateFile);
                 } catch (error) {
-                    this.logger.error(`Error reading sub template file '${subTemplateFile.path}'`, error);
+                    this.logger.error(
+                        `Error reading sub template file '${subTemplateFile.path}'`,
+                        error,
+                    );
                 }
             }
         } else if (templateFilePath) {
-            const templateFile = this.app.vault.getAbstractFileByPath(templateFilePath);
+            const templateFile =
+                this.app.vault.getAbstractFileByPath(templateFilePath);
+
             if (templateFile && templateFile instanceof TFile) {
                 try {
                     template = await this.app.vault.read(templateFile);
                 } catch (error) {
-                    this.logger.error(`Error reading template file '${templateFile.path}'`, error);
+                    this.logger.error(
+                        `Error reading template file '${templateFile.path}'`,
+                        error,
+                    );
                 }
             }
         }
@@ -167,122 +252,122 @@ export default class CreateNewTaskManagementModal extends BaseModalForm {
 
     protected constructForm(): FormConfiguration {
         const form: FormConfiguration = {
-            title: `${Lng.gt("New Topic/Project")}`,
-            name: "new task managment file",
-            customClassname: "",
-            fields: []
+            title: `${Lng.gt('New Topic/Project')}`,
+            name: 'new task managment file',
+            customClassname: '',
+            fields: [],
         };
 
         // Type
         const type: Field = {
-            name: "type",
-            label: Lng.gt("Task managment type"),
-            description: Lng.gt("Task managment type description"),
+            name: 'type',
+            label: Lng.gt('Task managment type'),
+            description: Lng.gt('Task managment type description'),
             isRequired: true,
             input: {
-                type: "select",
-                source: "fixed",
+                type: 'select',
+                source: 'fixed',
                 options: [
-                    { value: "Topic", label: Lng.gt("Topic") },
-                    { value: "Project", label: Lng.gt("Project") }
-                ]
-            }
+                    { value: 'Topic', label: Lng.gt('Topic') },
+                    { value: 'Project', label: Lng.gt('Project') },
+                ],
+            },
         };
         form.fields.push(type);
 
         // Title
         const title: Field = {
-            name: "title",
-            label: Lng.gt("Title"),
-            description: Lng.gt("Title description"),
+            name: 'title',
+            label: Lng.gt('Title'),
+            description: Lng.gt('Title description'),
             isRequired: true,
             input: {
-                type: "text"
-            }
+                type: 'text',
+            },
         };
         form.fields.push(title);
 
         // Description
         const description: Field = {
-            name: "description",
-            label: Lng.gt("Description"),
-            description: Lng.gt("Document description description"),
+            name: 'description',
+            label: Lng.gt('Description'),
+            description: Lng.gt('Document description description'),
             isRequired: false,
             input: {
-                type: "textarea"
-            }
+                type: 'textarea',
+            },
         };
         form.fields.push(description);
 
         // Status
         const status: Field = {
-            name: "status",
-            label: Lng.gt("Status"),
-            description: Lng.gt("Status description"),
+            name: 'status',
+            label: Lng.gt('Status'),
+            description: Lng.gt('Status description'),
             isRequired: true,
             input: {
-                type: "select",
-                "source": "fixed",
+                type: 'select',
+                source: 'fixed',
                 options: [
-                    { label: Lng.gt("StatusActive"), value: "Active" },
-                    { label: Lng.gt("StatusWaiting"), value: "Waiting" },
-                    { label: Lng.gt("StatusLater"), value: "Later" },
-                    { label: Lng.gt("StatusSomeday"), value: "Someday" },
-                    { label: Lng.gt("StatusDone"), value: "Done" }
-                ]
-            }
+                    { label: Lng.gt('StatusActive'), value: 'Active' },
+                    { label: Lng.gt('StatusWaiting'), value: 'Waiting' },
+                    { label: Lng.gt('StatusLater'), value: 'Later' },
+                    { label: Lng.gt('StatusSomeday'), value: 'Someday' },
+                    { label: Lng.gt('StatusDone'), value: 'Done' },
+                ],
+            },
         };
         form.fields.push(status);
 
         // Priority
         const priority: Field = {
-            name: "priority",
-            label: Lng.gt("Priority"),
-            description: Lng.gt("Priority description"),
+            name: 'priority',
+            label: Lng.gt('Priority'),
+            description: Lng.gt('Priority description'),
             isRequired: false,
             input: {
-                type: "slider",
+                type: 'slider',
                 min: 0,
-                max: 3
-            }
+                max: 3,
+            },
         };
         form.fields.push(priority);
 
         // Energy
         const energy: Field = {
-            name: "energy",
-            label: Lng.gt("Energy"),
-            description: Lng.gt("Energy description"),
+            name: 'energy',
+            label: Lng.gt('Energy'),
+            description: Lng.gt('Energy description'),
             isRequired: false,
             input: {
-                type: "slider",
+                type: 'slider',
                 min: 0,
-                max: 3
-            }
+                max: 3,
+            },
         };
         form.fields.push(energy);
 
         // Due Date
         const dueDate: Field = {
-            name: "dueDate",
-            label: Lng.gt("Due date"),
-            description: Lng.gt("Due date description"),
+            name: 'dueDate',
+            label: Lng.gt('Due date'),
+            description: Lng.gt('Due date description'),
             isRequired: false,
             input: {
-                type: "date"
-            }
+                type: 'date',
+            },
         };
         form.fields.push(dueDate);
 
         // Tags
         const tags: Field = {
-            name: "tags",
-            label: Lng.gt("Tags"),
-            description: Lng.gt("Tags description"),
+            name: 'tags',
+            label: Lng.gt('Tags'),
+            description: Lng.gt('Tags description'),
             isRequired: false,
             input: {
-                type: "tag"
-            }
+                type: 'tag',
+            },
         };
         form.fields.push(tags);
 
@@ -300,17 +385,18 @@ export default class CreateNewTaskManagementModal extends BaseModalForm {
 
         // Acronym
         const acronym: Field = {
-            name: "acronym",
-            label: Lng.gt("Acronym"),
-            description: Lng.gt("Acronym description"),
+            name: 'acronym',
+            label: Lng.gt('Acronym'),
+            description: Lng.gt('Acronym description'),
             isRequired: false,
             input: {
-                type: "document_block",
-                body: "if (form.type === \"Task\") " +
+                type: 'document_block',
+                body:
+                    'if (form.type === "Task") ' +
                     "return app.plugins.plugins.prj.api.helper.generateAcronym(form.title,3,'t');" +
-                    " else " +
-                    "return app.plugins.plugins.prj.api.helper.generateAcronym(form.title);"
-            }
+                    ' else ' +
+                    'return app.plugins.plugins.prj.api.helper.generateAcronym(form.title);',
+            },
         };
         form.fields.push(acronym);
 
@@ -324,19 +410,20 @@ export default class CreateNewTaskManagementModal extends BaseModalForm {
     public static registerCommand(): void {
         const global = Global.getInstance();
         global.logger.trace("Registering 'CreateTaskManagementModal' commands");
+
         global.plugin.addCommand({
-            id: "create-new-task-management-file",
-            name: `${Lng.gt("New Topic/Project")}`,
+            id: 'create-new-task-management-file',
+            name: `${Lng.gt('New Topic/Project')}`,
             callback: async () => {
                 const modal = new CreateNewTaskManagementModal();
                 const result = await modal.openForm();
+
                 if (result) {
                     const prj = await modal.evaluateForm(result);
-                    if (prj)
-                        await Helper.openFile(prj.file);
+
+                    if (prj) await Helper.openFile(prj.file);
                 }
             },
-        })
+        });
     }
-
 }

--- a/src/libs/Modals/CreateNewTaskModal.ts
+++ b/src/libs/Modals/CreateNewTaskModal.ts
@@ -1,39 +1,50 @@
-import { Field, FormConfiguration } from "src/types/ModalFormType";
-import CreateNewTaskManagementModal from "./CreateNewTaskManagementModal";
-import Lng from "src/classes/Lng";
-import Global from "src/classes/Global";
-import Helper from "../Helper";
+import { Field, FormConfiguration } from 'src/types/ModalFormType';
+import CreateNewTaskManagementModal from './CreateNewTaskManagementModal';
+import Lng from 'src/classes/Lng';
+import Global from 'src/classes/Global';
+import Helper from '../Helper';
 
 export default class CreateNewTaskModal extends CreateNewTaskManagementModal {
-
     protected override constructForm(): FormConfiguration {
         const form = super.constructForm();
-        form.title = `${Lng.gt("New")} ${Lng.gt("Project")}`;
+        form.title = `${Lng.gt('New')} ${Lng.gt('Project')}`;
 
-        const typeFieldIndex = form.fields.findIndex(field => field.name === "type");
-        if (typeFieldIndex !== -1 && form.fields[typeFieldIndex].input.type === "select") {
-            const selectInput = form.fields[typeFieldIndex].input as { type: "select", options: { value: string, label: string }[] };
-            selectInput.options = [
-                { value: "Task", label: Lng.gt("Task") },
-            ];
+        const typeFieldIndex = form.fields.findIndex(
+            (field) => field.name === 'type',
+        );
+
+        if (
+            typeFieldIndex !== -1 &&
+            form.fields[typeFieldIndex].input.type === 'select'
+        ) {
+            const selectInput = form.fields[typeFieldIndex].input as {
+                type: 'select';
+                options: { value: string; label: string }[];
+            };
+
+            selectInput.options = [{ value: 'Task', label: Lng.gt('Task') }];
         }
 
         // SubType
         const subType: Field = {
-            name: "subtype",
-            label: Lng.gt("SubType"),
-            description: Lng.gt("SubTypeDescription"),
+            name: 'subtype',
+            label: Lng.gt('SubType'),
+            description: Lng.gt('SubTypeDescription'),
             isRequired: false,
             input: {
-                type: "select",
-                source: "fixed",
-                options: []
-            }
+                type: 'select',
+                source: 'fixed',
+                options: [],
+            },
         };
 
-        const taskSubTypes = this.global.plugin.settings.prjSettings.subTaskTemplates?.map((value) => ({ value: value.template, label: value.label }));
-        if (taskSubTypes && subType.input.type === "select") {
-            subType.input.options.push({ value: "", label: Lng.gt("None") })
+        const taskSubTypes =
+            this.global.plugin.settings.prjSettings.subTaskTemplates?.map(
+                (value) => ({ value: value.template, label: value.label }),
+            );
+
+        if (taskSubTypes && subType.input.type === 'select') {
+            subType.input.options.push({ value: '', label: Lng.gt('None') });
             subType.input.options.push(...taskSubTypes);
         }
 
@@ -45,7 +56,6 @@ export default class CreateNewTaskModal extends CreateNewTaskManagementModal {
         return form;
     }
 
-
     /**
      * Registers the command to open the modal
      * @remarks No cleanup needed
@@ -53,18 +63,20 @@ export default class CreateNewTaskModal extends CreateNewTaskManagementModal {
     public static registerCommand(): void {
         const global = Global.getInstance();
         global.logger.trace("Registering 'CreateNewTaskModal' commands");
+
         global.plugin.addCommand({
-            id: "create-new-task-file",
-            name: `${Lng.gt("New task")}`,
+            id: 'create-new-task-file',
+            name: `${Lng.gt('New task')}`,
             callback: async () => {
                 const modal = new CreateNewTaskModal();
                 const result = await modal.openForm();
+
                 if (result) {
                     const prj = await modal.evaluateForm(result);
-                    if (prj)
-                        await Helper.openFile(prj.file);
+
+                    if (prj) await Helper.openFile(prj.file);
                 }
             },
-        })
+        });
     }
 }

--- a/src/libs/Search.ts
+++ b/src/libs/Search.ts
@@ -1,7 +1,6 @@
 // Note: SearchLib class
 
 export default class Search {
-
     /**
      * Parses the search text into an array of objects that represent the search terms
      * @param searchText The search text to parse
@@ -15,7 +14,9 @@ export default class Search {
 
         // Check if the search text contains quotes: If not, return the search text as a single term (no complex search logic)
         if (!searchText.includes('"')) {
-            return [{ term: searchText.trim(), negate: false, isOperator: false }];
+            return [
+                { term: searchText.trim(), negate: false, isOperator: false },
+            ];
         }
 
         const terms = [];
@@ -27,7 +28,11 @@ export default class Search {
             if (char === '"') {
                 if (inQuotes) {
                     // Save the term with negation status
-                    terms.push({ term: term.toLowerCase(), negate: negate, isOperator: false });
+                    terms.push({
+                        term: term.toLowerCase(),
+                        negate: negate,
+                        isOperator: false,
+                    });
                     term = '';
                     negate = false;
                 }
@@ -39,10 +44,15 @@ export default class Search {
                 continue;
             } else if (['&', '|', '!'].includes(char)) {
                 if (term.length > 0) {
-                    terms.push({ term: term, negate: negate, isOperator: false });
+                    terms.push({
+                        term: term,
+                        negate: negate,
+                        isOperator: false,
+                    });
                     term = '';
                     negate = false;
                 }
+
                 if (char === '!') {
                     negate = true;
                 } else {
@@ -60,14 +70,18 @@ export default class Search {
         // Check and add the default AND operator
         if (terms.length > 1) {
             let i = 0;
+
             while (i < terms.length - 1) {
                 if (!terms[i].isOperator && !terms[i + 1].isOperator) {
                     // Add the default AND operator between two non-operator terms
-                    terms.splice(i + 1, 0, { term: '&', negate: false, isOperator: true });
+                    terms.splice(i + 1, 0, {
+                        term: '&',
+                        negate: false,
+                        isOperator: true,
+                    });
                 }
                 i += 2; // Jump to the next pair of terms
             }
-
         }
 
         return terms;
@@ -79,17 +93,24 @@ export default class Search {
      * @param textContent The text content to apply the search logic to
      * @returns Whether the text content matches the search terms (true or false)
      */
-    static applySearchLogic(terms: SearchTermsArray, textContent: string): boolean {
+    static applySearchLogic(
+        terms: SearchTermsArray,
+        textContent: string,
+    ): boolean {
         textContent = textContent.toLowerCase();
 
         // If only one term is present..
-        let result = terms[0].negate ? !textContent.includes(terms[0].term) : textContent.includes(terms[0].term);
+        let result = terms[0].negate
+            ? !textContent.includes(terms[0].term)
+            : textContent.includes(terms[0].term);
 
         for (let i = 1; i < terms.length; i += 2) {
             const operatorObj = terms[i];
             const nextTermObj = terms[i + 1];
 
-            const nextTermMatch = nextTermObj.negate ? !textContent.includes(nextTermObj.term) : textContent.includes(nextTermObj.term);
+            const nextTermMatch = nextTermObj.negate
+                ? !textContent.includes(nextTermObj.term)
+                : textContent.includes(nextTermObj.term);
 
             if (operatorObj.term === '&') {
                 result = result && nextTermMatch;

--- a/src/libs/SingletonBlockProcessor.ts
+++ b/src/libs/SingletonBlockProcessor.ts
@@ -1,11 +1,11 @@
-import { MarkdownPostProcessorContext } from "obsidian";
-import { ILogger } from "src/interfaces/ILogger";
-import CustomizableRenderChild from "./CustomizableRenderChild";
+import { MarkdownPostProcessorContext } from 'obsidian';
+import { ILogger } from 'src/interfaces/ILogger';
+import CustomizableRenderChild from './CustomizableRenderChild';
 
 /**
  * Type for the view state.
  */
-export type ViewState = "source" | "preview";
+export type ViewState = 'source' | 'preview';
 
 /**
  * Class for the singleton block processor.
@@ -16,21 +16,21 @@ export type ViewState = "source" | "preview";
  * ```ts
  * //const uid = Create a unique id for the block.
  * const singletonBlockProcessor = new SingletonBlockProcessor(uid, el, ctx);
- * 
+ *
  * const singleToneBlock = singletonBlockProcessor.singletoneContainer;
  * el.append(singleToneBlock);
- * 
+ *
  * if (!singletonBlockProcessor.checkForSiblingBlocks()) {
  *    // If the block is not the only one in the workspace leaf,
  *    // return and do nothing in your `MarkdownCodeBlockProcessor`.
  *    return;
  * }
- * 
+ *
  * // Append your main parent container to the singletone container.
  * // This `mainContainer` container will be moved between the corosponding containers.
  * const mainContainer = document.createElement('div');
  * singleToneBlock.append(mainContainer);
- * 
+ *
  * // Work with your main container from here..
  * ```
  */
@@ -50,7 +50,9 @@ export default class SingletonBlockProcessor {
      * - Register a component with **this** container.
      */
     public get singletoneContainer(): HTMLElement {
-        this.singletonContainer = this.singletonContainer ?? this.getSingletoneContainer();
+        this.singletonContainer =
+            this.singletonContainer ?? this.getSingletoneContainer();
+
         return this.singletonContainer;
     }
 
@@ -72,7 +74,9 @@ export default class SingletonBlockProcessor {
      * Get the current workspace leaf state.
      */
     private get workspaceLeafState(): string | undefined {
-        return this.workspaceLeafContent?.getAttribute('data-mode') ?? undefined;
+        return (
+            this.workspaceLeafContent?.getAttribute('data-mode') ?? undefined
+        );
     }
 
     /**
@@ -86,14 +90,22 @@ export default class SingletonBlockProcessor {
      * Get the source sibling block.
      */
     private get sourceSiblingBlock(): Element | undefined {
-        return this.workspaceLeafContent?.querySelector(`#${this.uid}[data-mode='source']`) ?? undefined;
+        return (
+            this.workspaceLeafContent?.querySelector(
+                `#${this.uid}[data-mode='source']`,
+            ) ?? undefined
+        );
     }
 
     /**
      * Get the preview sibling block.
      */
     private get previewSiblingBlock(): Element | undefined {
-        return this.workspaceLeafContent?.querySelector(`#${this.uid}[data-mode='preview']`) ?? undefined;
+        return (
+            this.workspaceLeafContent?.querySelector(
+                `#${this.uid}[data-mode='preview']`,
+            ) ?? undefined
+        );
     }
 
     /**
@@ -106,8 +118,8 @@ export default class SingletonBlockProcessor {
         uid: string,
         el: HTMLElement,
         ctx: MarkdownPostProcessorContext,
-        logger?: ILogger) {
-
+        logger?: ILogger,
+    ) {
         this.logger = logger ?? undefined;
         this.uid = uid;
         this.el = el;
@@ -133,13 +145,24 @@ export default class SingletonBlockProcessor {
     public checkForSiblingBlocks(): boolean {
         const blockViewState = this.codeBlockViewState;
         const viewState = this.workspaceLeafState;
-        if (blockViewState === viewState && (this.siblingBlocks && this.siblingBlocks.length == 1)) {
+
+        if (
+            blockViewState === viewState &&
+            this.siblingBlocks &&
+            this.siblingBlocks.length == 1
+        ) {
             return true;
         } else {
             const source = this.sourceSiblingBlock;
             const preview = this.previewSiblingBlock;
-            return !this.moveChildrenToCorrespondingViewState(blockViewState, source, preview);
+
+            return !this.moveChildrenToCorrespondingViewState(
+                blockViewState,
+                source,
+                preview,
+            );
         }
+
         return true;
     }
 
@@ -147,6 +170,7 @@ export default class SingletonBlockProcessor {
         if (!this.workspaceLeafContent) {
             return;
         }
+
         // If a sibling block is available, we dont need to create an observer
         // because one observer is enough for all sibling blocks.
         if (this.siblingBlocks && this.siblingBlocks.length === 1) {
@@ -164,22 +188,40 @@ export default class SingletonBlockProcessor {
         }
 
         // Create a observer component. To `disconnect` the observer on unload.
-        this.observerChild = new CustomizableRenderChild(this.singletoneContainer, undefined, this.onUnload, this.logger);
+        this.observerChild = new CustomizableRenderChild(
+            this.singletoneContainer,
+            undefined,
+            this.onUnload,
+            this.logger,
+        );
 
         this.observer = new MutationObserver((mutations) => {
-            this.logger?.trace("Observer detect changes:", mutations, `UID: ${this.uid}`);
+            this.logger?.trace(
+                'Observer detect changes:',
+                mutations,
+                `UID: ${this.uid}`,
+            );
+
             for (const mutation of mutations) {
-                if (mutation.type === 'attributes' && mutation.attributeName === 'data-mode') {
+                if (
+                    mutation.type === 'attributes' &&
+                    mutation.attributeName === 'data-mode'
+                ) {
                     const newViewState = this.workspaceLeafState;
                     const source = this.sourceSiblingBlock;
                     const preview = this.previewSiblingBlock;
-                    this.moveChildrenToCorrespondingViewState(newViewState, source, preview);
+
+                    this.moveChildrenToCorrespondingViewState(
+                        newViewState,
+                        source,
+                        preview,
+                    );
                 }
             }
         });
 
         this.observer.observe(this.workspaceLeafContent, {
-            attributes: true
+            attributes: true,
         });
 
         // Add the observer component to the context.
@@ -197,15 +239,18 @@ export default class SingletonBlockProcessor {
     private moveChildrenToCorrespondingViewState(
         blockViewState: string | undefined,
         source: Element | undefined,
-        preview: Element | undefined): boolean {
+        preview: Element | undefined,
+    ): boolean {
+        if (blockViewState === 'source' && source && preview) {
+            this.logger?.debug('Move preview to source', `UID: ${this.uid}`);
 
-        if (blockViewState === "source" && source && preview) {
-            this.logger?.debug("Move preview to source", `UID: ${this.uid}`);
             return this.moveChilds(preview, source);
-        } else if (blockViewState === "preview" && source && preview) {
-            this.logger?.debug("Move source to preview", `UID: ${this.uid}`);
+        } else if (blockViewState === 'preview' && source && preview) {
+            this.logger?.debug('Move source to preview', `UID: ${this.uid}`);
+
             return this.moveChilds(source, preview);
         }
+
         return false;
     }
 
@@ -217,16 +262,19 @@ export default class SingletonBlockProcessor {
      */
     private moveChilds(from: Element, to: Element): boolean {
         let elementsMoved = false;
+
         while (from.firstChild) {
             const child = from.firstChild;
+
             if (child.childNodes.length > 0) {
                 elementsMoved = true;
                 to.appendChild(child);
             } else {
-                this.logger?.warn("Child has no child nodes", child);
+                this.logger?.warn('Child has no child nodes', child);
                 from.removeChild(child);
             }
         }
+
         return elementsMoved;
     }
 
@@ -239,7 +287,12 @@ export default class SingletonBlockProcessor {
     private getSingletoneContainer(): HTMLElement {
         const singletoneContainer = document.createElement('div');
         singletoneContainer.id = this.uid;
-        singletoneContainer.setAttribute('data-mode', this.getCodeBlockViewState(true) ?? "none");
+
+        singletoneContainer.setAttribute(
+            'data-mode',
+            this.getCodeBlockViewState(true) ?? 'none',
+        );
+
         return singletoneContainer;
     }
 
@@ -251,12 +304,25 @@ export default class SingletonBlockProcessor {
     private getCodeBlockViewState(logging = false): ViewState | undefined {
         const sourceView = this.el.closest('.markdown-source-view');
         const readingView = this.el.closest('.markdown-reading-view');
+
         if (sourceView) {
-            (!logging) ? this.logger?.debug(`CodeBlock View state: 'source'`, `UID: ${this.uid}`) : undefined;
-            return "source";
+            !logging
+                ? this.logger?.debug(
+                      `CodeBlock View state: 'source'`,
+                      `UID: ${this.uid}`,
+                  )
+                : undefined;
+
+            return 'source';
         } else if (readingView) {
-            (!logging) ? this.logger?.debug(`CodeBlock View state: 'preview'`, `UID: ${this.uid}`) : undefined;
-            return "preview";
+            !logging
+                ? this.logger?.debug(
+                      `CodeBlock View state: 'preview'`,
+                      `UID: ${this.uid}`,
+                  )
+                : undefined;
+
+            return 'preview';
         }
 
         return undefined;

--- a/src/libs/Table.ts
+++ b/src/libs/Table.ts
@@ -1,5 +1,5 @@
-import Global from "../classes/Global";
-import Helper from "./Helper";
+import Global from '../classes/Global';
+import Helper from './Helper';
 
 export default class Table {
     public get data(): StructedTable {
@@ -31,11 +31,11 @@ export default class Table {
 
         hiddenRow: 'hidden-row',
         evenRow: 'even-row',
-        oddRow: 'odd-row'
+        oddRow: 'odd-row',
     };
-    // Default IDs 
+    // Default IDs
     private defaultIds = {
-        placeholder: "placeholder-row"
+        placeholder: 'placeholder-row',
     };
     // // //// // //// // //
 
@@ -45,7 +45,11 @@ export default class Table {
      * @param id The ID of the table
      * @param classList The class list of the table
      */
-    constructor(tableHeaders: TableHeader[], id: string, classList: string[] | undefined) {
+    constructor(
+        tableHeaders: TableHeader[],
+        id: string,
+        classList: string[] | undefined,
+    ) {
         this._headers = tableHeaders;
         this._tableId = id;
         this._tableClassList = classList;
@@ -67,8 +71,9 @@ export default class Table {
         const table = document.createElement('table');
         table.id = this._tableId;
         table.classList.add(...this.defaultClasses.table);
+
         if (this._tableClassList) {
-            this._tableClassList.forEach(classItem => {
+            this._tableClassList.forEach((classItem) => {
                 table.classList.add(classItem);
             });
         }
@@ -79,13 +84,15 @@ export default class Table {
         tableHeaderRow.classList.add(...this.defaultClasses.headerRow);
 
         const tableHeaderCells: HTMLTableCellElement[] = [];
-        this._headers.forEach(header => {
+
+        this._headers.forEach((header) => {
             const tableHeaderCell = document.createElement('th');
             tableHeaderCell.classList.add(...this.defaultClasses.headerCell);
             tableHeaderCell.id = this.makeSafeForId(header.text);
             tableHeaderCell.textContent = header.text;
+
             if (header.headerClass) {
-                header.headerClass.forEach(classItem => {
+                header.headerClass.forEach((classItem) => {
                     tableHeaderCell.classList.add(classItem);
                 });
             }
@@ -101,7 +108,7 @@ export default class Table {
             headerRow: tableHeaderRow,
             headerCells: tableHeaderCells,
             body: tableBody,
-            rows: []
+            rows: [],
         };
 
         return structedTable;
@@ -131,14 +138,22 @@ export default class Table {
      */
     public addRows(rows: Row[]): void {
         const collectedRows = document.createDocumentFragment();
-        rows.forEach(row => {
-            const rowFragment = this.createRow(row.rowUid, row.rowData, row.rowClassList, row.hidden);
+
+        rows.forEach((row) => {
+            const rowFragment = this.createRow(
+                row.rowUid,
+                row.rowData,
+                row.rowClassList,
+                row.hidden,
+            );
+
             if (rowFragment) {
                 this._table.rows.push(rowFragment);
+
                 if (row.hidden) {
                     collectedRows.append(this._getPlaceholder(row.rowUid));
                 } else {
-                    collectedRows.append(rowFragment)
+                    collectedRows.append(rowFragment);
                 }
             }
         });
@@ -154,36 +169,48 @@ export default class Table {
      * @remarks - The row is added to the internal array.
      * - If the row is hidden, the row content is replaced with a placeholder.
      */
-    private _addRow(rowUid: string, rowData: DocumentFragment[], rowClassList: string[] | undefined, hidden: boolean): void {
+    private _addRow(
+        rowUid: string,
+        rowData: DocumentFragment[],
+        rowClassList: string[] | undefined,
+        hidden: boolean,
+    ): void {
         const tableRow = this.createRow(rowUid, rowData, rowClassList, hidden);
         this._table.rows.push(tableRow);
 
         if (hidden) {
             this._table.body.append(this._getPlaceholder(rowUid));
         } else {
-            this._table.body.append(tableRow)
+            this._table.body.append(tableRow);
         }
     }
 
     /**
      * Creates a row
-     * @param rowUid The UID of the row 
+     * @param rowUid The UID of the row
      * @param rowData The data of the row as an array of DocumentFragments. Each DocumentFragment represents a cell.
      * @param rowClassList The class list of the row
      * @param hidden Whether the row should be hidden.
      * @remarks **If true, the row is hidden and the row content is later replaced with a placeholder.**
      * @returns The created row as an HTMLTableRowElement
      */
-    private createRow(rowUid: string, rowData: DocumentFragment[], rowClassList: string[] | undefined, hidden: boolean): HTMLTableRowElement {
+    private createRow(
+        rowUid: string,
+        rowData: DocumentFragment[],
+        rowClassList: string[] | undefined,
+        hidden: boolean,
+    ): HTMLTableRowElement {
         const tableRow = document.createElement('tr');
 
         tableRow.classList.add(...this.defaultClasses.row);
         tableRow.setAttribute('row-uid', rowUid);
+
         if (rowClassList) {
-            rowClassList.forEach(classItem => {
+            rowClassList.forEach((classItem) => {
                 tableRow.classList.add(classItem);
             });
         }
+
         if (hidden) {
             tableRow.classList.add(this.defaultClasses.hiddenRow);
             this._hiddenRows++;
@@ -191,21 +218,28 @@ export default class Table {
             this.setRowOddOrEven(tableRow);
             this._visibleRows++;
         }
+
         rowData.forEach((data, index) => {
             const tableCell = tableRow.insertCell();
             tableCell.classList.add(...this.defaultClasses.cell);
-            if (this._headers[index] !== undefined && this._headers[index].columnClass) {
-                this._headers[index].columnClass?.forEach(classItem => {
+
+            if (
+                this._headers[index] !== undefined &&
+                this._headers[index].columnClass
+            ) {
+                this._headers[index].columnClass?.forEach((classItem) => {
                     tableCell.classList.add(classItem);
                 });
             }
             // Add Label attribute to the cell
             tableCell.setAttribute('data-label', this._headers[index].text);
+
             if (Helper.isEmoji(this._headers[index].text)) {
                 tableCell.classList.add(...this.defaultClasses.emojiCell);
             }
             tableCell.appendChild(data);
         });
+
         return tableRow;
     }
 
@@ -218,14 +252,24 @@ export default class Table {
      */
     private setRowOddOrEven(tableRow: HTMLTableRowElement) {
         let lastVisibleRow;
+
         for (let i = this._table.rows.length - 1; i >= 0; i--) {
-            if (!this._table.rows[i].classList.contains(this.defaultClasses.hiddenRow)) {
+            if (
+                !this._table.rows[i].classList.contains(
+                    this.defaultClasses.hiddenRow,
+                )
+            ) {
                 lastVisibleRow = this._table.rows[i];
                 break;
             }
         }
+
         if (lastVisibleRow) {
-            tableRow.classList.add(lastVisibleRow.classList.contains(this.defaultClasses.evenRow) ? this.defaultClasses.oddRow : this.defaultClasses.evenRow);
+            tableRow.classList.add(
+                lastVisibleRow.classList.contains(this.defaultClasses.evenRow)
+                    ? this.defaultClasses.oddRow
+                    : this.defaultClasses.evenRow,
+            );
         } else {
             tableRow.classList.add(this.defaultClasses.evenRow);
         }
@@ -237,7 +281,7 @@ export default class Table {
      * @returns visibleRows The number of visible rows
      * @returns hiddenRows The number of hidden rows
      */
-    public getRowStats(): { visibleRows: number, hiddenRows: number } {
+    public getRowStats(): { visibleRows: number; hiddenRows: number } {
         return { visibleRows: this._visibleRows, hiddenRows: this._hiddenRows };
     }
 
@@ -249,26 +293,40 @@ export default class Table {
      */
     public deleteRow(rowUid: string): void {
         const rowToDelete = this.getRow(rowUid);
-        const rowVisible = rowToDelete && !rowToDelete.classList.contains(this.defaultClasses.hiddenRow);
+
+        const rowVisible =
+            rowToDelete &&
+            !rowToDelete.classList.contains(this.defaultClasses.hiddenRow);
+
         if (rowVisible) {
             if (rowToDelete) {
                 try {
                     this._table.body.removeChild(rowToDelete);
                 } catch (error) {
-                    this.logger.warn("Row not active in the table. Error:", error);
+                    this.logger.warn(
+                        'Row not active in the table. Error:',
+                        error,
+                    );
                 }
-                this._table.rows = this._table.rows.filter(row => row.getAttribute('row-uid') !== rowUid);
+
+                this._table.rows = this._table.rows.filter(
+                    (row) => row.getAttribute('row-uid') !== rowUid,
+                );
                 this._removePlaceholder(rowUid);
             }
             this._visibleRows--;
             this.refreshRowEvenOddClass();
         } else {
             const placeholder = this._removePlaceholder(rowUid);
+
             if (placeholder) {
                 try {
                     this._table.body.removeChild(placeholder);
                 } catch (error) {
-                    this.logger.warn("Placeholder row not active in the table. Error:", error);
+                    this.logger.warn(
+                        'Placeholder row not active in the table. Error:',
+                        error,
+                    );
                 }
             }
             this._hiddenRows--;
@@ -283,8 +341,8 @@ export default class Table {
      */
     public hideRow(rowUid: string): void {
         const changes = this._hideRow(rowUid);
-        if (changes)
-            this.refreshRowEvenOddClass();
+
+        if (changes) this.refreshRowEvenOddClass();
     }
 
     /**
@@ -294,8 +352,14 @@ export default class Table {
      */
     private _hideRow(rowUid: string): boolean {
         this.logger.trace(`Row ${rowUid} should be hidden.`);
-        const changes = this.togleRowClass(rowUid, [this.defaultClasses.hiddenRow], true);
+
+        const changes = this.togleRowClass(
+            rowUid,
+            [this.defaultClasses.hiddenRow],
+            true,
+        );
         this.logger.trace(`Row ${rowUid} changes: ${changes}`);
+
         if (changes) {
             this._removeRowContent(rowUid);
             this._visibleRows--;
@@ -313,8 +377,8 @@ export default class Table {
      */
     public showRow(rowUid: string): void {
         const changes = this._showRow(rowUid);
-        if (changes)
-            this.refreshRowEvenOddClass();
+
+        if (changes) this.refreshRowEvenOddClass();
     }
 
     /**
@@ -324,8 +388,14 @@ export default class Table {
      */
     private _showRow(rowUid: string): boolean {
         this.logger.trace(`Row ${rowUid} should be shown.`);
-        const changes = this.togleRowClass(rowUid, [this.defaultClasses.hiddenRow], false);
+
+        const changes = this.togleRowClass(
+            rowUid,
+            [this.defaultClasses.hiddenRow],
+            false,
+        );
         this.logger.trace(`Row ${rowUid} changes: ${changes}`);
+
         if (changes) {
             this._addRowContent(rowUid);
             this._visibleRows++;
@@ -344,8 +414,12 @@ export default class Table {
     public async changeShowHideStateRows(rows: RowsState[]): Promise<void> {
         this.logger.trace(`Change Show/Hide state of ${rows.length} rows.`);
         let changes = false;
-        rows.forEach(row => {
-            this.logger.trace(`Change Show/Hide state of Row: ${row.rowUid} to ${row.hidden}.`);
+
+        rows.forEach((row) => {
+            this.logger.trace(
+                `Change Show/Hide state of Row: ${row.rowUid} to ${row.hidden}.`,
+            );
+
             if (row.hidden) {
                 this.logger.trace(`Hide Row: ${row.rowUid}`);
                 const result = this._hideRow(row.rowUid);
@@ -356,8 +430,8 @@ export default class Table {
                 changes ||= result;
             }
         });
-        if (changes)
-            this.refreshRowEvenOddClass();
+
+        if (changes) this.refreshRowEvenOddClass();
     }
 
     /**
@@ -368,6 +442,7 @@ export default class Table {
      */
     private _removeRowContent(rowUid: string): void {
         const row = this.getRow(rowUid);
+
         if (row) {
             const placeholder = this._getPlaceholder(rowUid);
             this._table.body.replaceChild(placeholder, row);
@@ -382,13 +457,18 @@ export default class Table {
      */
     private _addRowContent(rowUid: string): void {
         const row = this.getRow(rowUid);
+
         if (row) {
             const placeholder = this._getPlaceholder(rowUid);
+
             if (placeholder) {
                 try {
                     this._table.body.replaceChild(row, placeholder);
                 } catch (error) {
-                    this.logger.warn("Placeholder row not active in the table. Error:", error);
+                    this.logger.warn(
+                        'Placeholder row not active in the table. Error:',
+                        error,
+                    );
                 }
             }
         }
@@ -406,6 +486,7 @@ export default class Table {
         placeholder.id = this.defaultIds.placeholder;
         placeholder.setAttribute('row-uid', rowUid);
         this._rowPlaceholders.push({ rowUid: rowUid, row: placeholder });
+
         return placeholder;
     }
 
@@ -413,11 +494,19 @@ export default class Table {
      * Removes the placeholder row with the given UID from the internal array
      * @param rowUid The UID of the row
      */
-    private _removePlaceholder(rowUid: string): HTMLTableRowElement | undefined {
-        const placeholder = this._rowPlaceholders.find(rowPlaceholder => rowPlaceholder.rowUid === rowUid)?.row;
+    private _removePlaceholder(
+        rowUid: string,
+    ): HTMLTableRowElement | undefined {
+        const placeholder = this._rowPlaceholders.find(
+            (rowPlaceholder) => rowPlaceholder.rowUid === rowUid,
+        )?.row;
+
         if (placeholder) {
-            this._rowPlaceholders = this._rowPlaceholders.filter(rowPlaceholder => rowPlaceholder.rowUid !== rowUid);
+            this._rowPlaceholders = this._rowPlaceholders.filter(
+                (rowPlaceholder) => rowPlaceholder.rowUid !== rowUid,
+            );
         }
+
         return placeholder;
     }
 
@@ -429,9 +518,11 @@ export default class Table {
      * @remarks - If a new placeholder row is generated, it is added to the internal array.
      */
     private _getPlaceholder(rowUid: string): HTMLTableRowElement {
-        const placeholder = this._rowPlaceholders.find(rowPlaceholder => rowPlaceholder.rowUid === rowUid)?.row;
-        if (placeholder)
-            return placeholder;
+        const placeholder = this._rowPlaceholders.find(
+            (rowPlaceholder) => rowPlaceholder.rowUid === rowUid,
+        )?.row;
+
+        if (placeholder) return placeholder;
         else {
             return this._generatePlaceholder(rowUid);
         }
@@ -443,7 +534,9 @@ export default class Table {
      * @returns The row with the given UID or undefined if no row with the given UID exists
      */
     public getRow(rowUid: string): HTMLTableRowElement | undefined {
-        return this._table.rows.find(row => row.getAttribute('row-uid') === rowUid);
+        return this._table.rows.find(
+            (row) => row.getAttribute('row-uid') === rowUid,
+        );
     }
 
     /**
@@ -452,12 +545,18 @@ export default class Table {
      * @param classList The class list to toggle
      * @param add Whether to add or remove the class
      */
-    public togleRowClass(rowUid: string, classList: string[], add: boolean): boolean {
+    public togleRowClass(
+        rowUid: string,
+        classList: string[],
+        add: boolean,
+    ): boolean {
         let changes = false;
         const row = this.getRow(rowUid);
+
         if (row) {
             changes = this.toggleClass(row, classList, add);
         }
+
         return changes;
     }
 
@@ -467,7 +566,10 @@ export default class Table {
      * - Change the classes only if necessary.
      */
     private refreshRowEvenOddClass(): void {
-        const visibleRows = this._table.rows.filter(row => !row.classList.contains(this.defaultClasses.hiddenRow));
+        const visibleRows = this._table.rows.filter(
+            (row) => !row.classList.contains(this.defaultClasses.hiddenRow),
+        );
+
         visibleRows.forEach((row, index) => {
             if (index % 2 === 0) {
                 this.toggleClass(row, [this.defaultClasses.evenRow], true);
@@ -481,30 +583,36 @@ export default class Table {
 
     /**
      * Toggles the specified classes on the given element.
-     * 
+     *
      * @param element - The HTML element to toggle the classes on.
      * @param classList - An array of classes to toggle.
      * @param add - A boolean value indicating whether to add or remove the classes.
      * @returns A boolean value indicating whether any changes were made to the element's class list.
      */
-    private toggleClass(element: HTMLElement, classList: string[], add: boolean): boolean {
+    private toggleClass(
+        element: HTMLElement,
+        classList: string[],
+        add: boolean,
+    ): boolean {
         let changes = false;
         const presentClasses = element.classList;
+
         if (add) {
-            classList.forEach(classItem => {
+            classList.forEach((classItem) => {
                 if (!presentClasses.contains(classItem)) {
                     element.classList.add(classItem);
                     changes = true;
                 }
             });
         } else {
-            classList.forEach(classItem => {
+            classList.forEach((classItem) => {
                 if (presentClasses.contains(classItem)) {
                     element.classList.remove(classItem);
                     changes = true;
                 }
             });
         }
+
         return changes;
     }
 
@@ -515,17 +623,26 @@ export default class Table {
     public changeHeader(header: TableHeader): void {
         this.changeHeaderClass(header);
         this.changeColumnClass(header);
-        this._headers[this._headers.findIndex(headerItem => headerItem.text === header.text)] = header;
+
+        this._headers[
+            this._headers.findIndex(
+                (headerItem) => headerItem.text === header.text,
+            )
+        ] = header;
     }
 
     private changeHeaderClass(header: TableHeader): void {
-        const headerIndex = this._headers.findIndex(headerItem => headerItem.text === header.text);
+        const headerIndex = this._headers.findIndex(
+            (headerItem) => headerItem.text === header.text,
+        );
         const oldHeaderClasses = this._headers[headerIndex].headerClass;
         const newHeaderClasses = header.headerClass;
         const headerCell = this._table.headerCells[headerIndex];
+
         if (oldHeaderClasses) {
             this.toggleClass(headerCell, oldHeaderClasses, false);
         }
+
         if (newHeaderClasses) {
             this.toggleClass(headerCell, newHeaderClasses, true);
         }
@@ -536,14 +653,19 @@ export default class Table {
      * @param header - The table header object.
      */
     private changeColumnClass(header: TableHeader): void {
-        const columnIndex = this._headers.findIndex(headerItem => headerItem.text === header.text);
+        const columnIndex = this._headers.findIndex(
+            (headerItem) => headerItem.text === header.text,
+        );
         const oldHeaderClasses = this._headers[columnIndex].headerClass;
-        this._table.rows.forEach(row => {
+
+        this._table.rows.forEach((row) => {
             const cell = row.cells[columnIndex];
+
             if (cell) {
                 if (oldHeaderClasses) {
                     this.toggleClass(cell, oldHeaderClasses, false);
                 }
+
                 if (header.columnClass) {
                     this.toggleClass(cell, header.columnClass, true);
                 }
@@ -553,7 +675,7 @@ export default class Table {
 
     /**
      * Makes the input string safe for use as an ID.
-     * 
+     *
      * @param input - The input string to be made safe.
      * @returns The safe ID string.
      */
@@ -598,7 +720,7 @@ export type TableHeader = {
      * The CSS classes applied to the column.
      */
     columnClass: string[] | undefined;
-}
+};
 
 /**
  * Represents a structured table.
@@ -610,7 +732,7 @@ export type StructedTable = {
     headerCells: HTMLTableCellElement[];
     body: HTMLTableSectionElement;
     rows: HTMLTableRowElement[];
-}
+};
 
 /**
  * Represents a placeholder for a table row.
@@ -618,7 +740,7 @@ export type StructedTable = {
 type RowPlaceholder = {
     rowUid: string;
     row: HTMLTableRowElement;
-}
+};
 
 /**
  * Represents a row in a table.
@@ -640,7 +762,7 @@ export type Row = {
      * Indicates whether the row is hidden or not.
      */
     hidden: boolean;
-}
+};
 
 /**
  * Represents the state of a row in a table.
@@ -648,4 +770,4 @@ export type Row = {
 export type RowsState = {
     rowUid: string;
     hidden: boolean;
-}
+};

--- a/src/libs/Tags.ts
+++ b/src/libs/Tags.ts
@@ -2,7 +2,6 @@
 
 import Global from 'src/classes/Global';
 
-
 /**
  * Represents a hierarchical tree structure for tags.
  */
@@ -11,7 +10,6 @@ export type TagTree = {
 };
 
 export default class Tags {
-
     /**
      * Checks if the tag is a valid tag array
      * @param tag The tag array to check
@@ -26,13 +24,14 @@ export default class Tags {
      * @param tags The tag/s to return the valid tags array from
      * @returns The valid tags array
      */
-    static getValidTags(tags: string | Array<string> | undefined): Array<string> {
+    static getValidTags(
+        tags: string | Array<string> | undefined,
+    ): Array<string> {
         let formattedTags: string[] = [];
 
         if (tags && typeof tags === 'string') {
             formattedTags = [tags];
-        }
-        else if (Array.isArray(tags)) {
+        } else if (Array.isArray(tags)) {
             formattedTags = [...tags];
         }
 
@@ -41,12 +40,15 @@ export default class Tags {
 
     /**
      * Creates an Obsidian tag link element.
-     * 
+     *
      * @param tagLabel - The label for the tag.
      * @param tag - The tag value.
      * @returns The created HTML anchor element.
      */
-    static createObsidianTagLink(tagLabel: string, tag: string): HTMLAnchorElement {
+    static createObsidianTagLink(
+        tagLabel: string,
+        tag: string,
+    ): HTMLAnchorElement {
         const obsidianLink = document.createElement('a');
         obsidianLink.href = `#${tag}`;
         obsidianLink.classList.add('tag');
@@ -61,15 +63,21 @@ export default class Tags {
      * Filters out the non specific tags from the given tags array
      * @param tags The tags array to filter out the non specific tags from
      * @returns The tags array without the non specific tags
-     * @example removeRedundantTags(["tag1", "tag2", "tag1/subtag1", "tag1/subtag2"]) => ["tag2", "tag1/subtag1", "tag1/subtag2"] 
+     * @example removeRedundantTags(["tag1", "tag2", "tag1/subtag1", "tag1/subtag2"]) => ["tag2", "tag1/subtag1", "tag1/subtag2"]
      */
     static filterOutNonSpecificTags(tags: Array<string>): Array<string> {
         let cleanedTags: Array<string> = [];
+
         if (this.isValidTag(tags)) {
-            cleanedTags = tags.filter(tag =>
-                !tags.some(otherTag => otherTag !== tag && otherTag.startsWith(tag + "/"))
+            cleanedTags = tags.filter(
+                (tag) =>
+                    !tags.some(
+                        (otherTag) =>
+                            otherTag !== tag && otherTag.startsWith(tag + '/'),
+                    ),
             );
         }
+
         return cleanedTags;
     }
 
@@ -85,13 +93,15 @@ export default class Tags {
             tag = `#${tag}`;
         }
 
-        const existFile = metadataCache.cache.find(file => {
+        const existFile = metadataCache.cache.find((file) => {
             const tags = file.metadata?.frontmatter?.tags;
+
             if (typeof tags === 'string') {
                 return tags === tag;
             } else if (Array.isArray(tags)) {
                 return tags.includes(tag);
             }
+
             return false;
         });
 
@@ -106,11 +116,11 @@ export default class Tags {
     static createTagTree(tags: Array<string>): TagTree {
         const tagTree: TagTree = {};
 
-        tags.forEach(tag => {
+        tags.forEach((tag) => {
             const parts = tag.split('/');
             let currentLevel = tagTree;
 
-            parts.forEach(part => {
+            parts.forEach((part) => {
                 if (!currentLevel[part]) {
                     currentLevel[part] = {};
                 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,89 +17,105 @@ import Lng from './classes/Lng';
 import Helper from './libs/Helper';
 
 export default class Prj extends Plugin {
-	public settings: PrjSettings;
-	public api: API = API;
+    public settings: PrjSettings;
+    public api: API = API;
 
-	async onload() {
-		console.log("Loading plugin 'PRJ'")
-		await this.loadSettings();
+    async onload() {
+        // eslint-disable-next-line no-console
+        console.log("Loading plugin 'PRJ'");
+        await this.loadSettings();
 
-		this.addSettingTab(new SettingTab(this.app, this));
+        this.addSettingTab(new SettingTab(this.app, this));
 
-		if (this.app.workspace.layoutReady) {
-			await this.onLayoutReady();
-		} else {
-			this.app.workspace.onLayoutReady(this.onLayoutReady.bind(this));
-		}
-	}
+        if (this.app.workspace.layoutReady) {
+            await this.onLayoutReady();
+        } else {
+            this.app.workspace.onLayoutReady(this.onLayoutReady.bind(this));
+        }
+    }
 
-	async onLayoutReady(): Promise<void> {
-		console.log("Layout ready");
+    async onLayoutReady(): Promise<void> {
+        // eslint-disable-next-line no-console
+        console.log('Layout ready');
 
-		new Global(this, this.app, this.settings);
-		await Global.getInstance().awaitCacheInitialization();
+        new Global(this, this.app, this.settings);
+        await Global.getInstance().awaitCacheInitialization();
 
-		this.registerMarkdownCodeBlockProcessor('prj', MarkdownBlockProcessor.parseSource);
+        this.registerMarkdownCodeBlockProcessor(
+            'prj',
+            MarkdownBlockProcessor.parseSource,
+        );
 
-		this.app.workspace.updateOptions();
+        this.app.workspace.updateOptions();
 
-		// Get Metadata File Context Menu & Command
-		GetMetadata.getInstance();
+        // Get Metadata File Context Menu & Command
+        GetMetadata.getInstance();
 
-		// Create New Metadata File Command
-		CreateNewMetadataModal.registerCommand();
+        // Create New Metadata File Command
+        CreateNewMetadataModal.registerCommand();
 
-		// Create new Task Managment Command
-		CreateNewTaskManagementModal.registerCommand();
-		// Create new Task Command
-		CreateNewTaskModal.registerCommand();
-		// Add Annotation Command
-		AddAnnotationModal.registerCommand();
+        // Create new Task Managment Command
+        CreateNewTaskManagementModal.registerCommand();
+        // Create new Task Command
+        CreateNewTaskModal.registerCommand();
+        // Add Annotation Command
+        AddAnnotationModal.registerCommand();
 
-		// Change Status Command
-		ChangeStatusModal.registerCommand();
+        // Change Status Command
+        ChangeStatusModal.registerCommand();
 
-		//Register event on `Status` change..
-		Global.getInstance().metadataCache.on('prj-task-management-changed-status', (file) => {
-			StaticPrjTaskManagementModel.syncStatusToPath(file);
-		});
+        //Register event on `Status` change..
+        Global.getInstance().metadataCache.on(
+            'prj-task-management-changed-status',
+            (file) => {
+                StaticPrjTaskManagementModel.syncStatusToPath(file);
+            },
+        );
 
-		//Register event on `Document Metadata` change..
-		Global.getInstance().metadataCache.on('document-changed-metadata', (file) => {
-			StaticDocumentModel.syncMetadataToFile(file);
-		});
+        //Register event on `Document Metadata` change..
+        Global.getInstance().metadataCache.on(
+            'document-changed-metadata',
+            (file) => {
+                StaticDocumentModel.syncMetadataToFile(file);
+            },
+        );
 
-		// Register rebuild View command:
-		this.addCommand({
-			id: "rebuild-active-view",
-			name: Lng.gt("Rebuild active view"),
-			callback: async () => {
-				Helper.rebuildActiveView();
-			},
-		});
+        // Register rebuild View command:
+        this.addCommand({
+            id: 'rebuild-active-view',
+            name: Lng.gt('Rebuild active view'),
+            callback: async () => {
+                Helper.rebuildActiveView();
+            },
+        });
 
-		/**
-		 * Run rebuild active view after 500ms
-		 * This is a workaround for the problem
-		 * that the plugin is not loaded when the
-		 * start page is loaded.
-		 */
-		setTimeout(() => {
-			Helper.rebuildActiveView();
-		}, 500);
-	}
+        /**
+         * Run rebuild active view after 500ms
+         * This is a workaround for the problem
+         * that the plugin is not loaded when the
+         * start page is loaded.
+         */
+        setTimeout(() => {
+            Helper.rebuildActiveView();
+        }, 500);
+    }
 
-	onunload() {
-		console.log("Unloading plugin 'PRJ'")
-		GetMetadata.deconstructor();
-		Global.deconstructor();
-	}
+    onunload() {
+        // eslint-disable-next-line no-console
+        console.log("Unloading plugin 'PRJ'");
+        GetMetadata.deconstructor();
+        Global.deconstructor();
+    }
 
-	async loadSettings() {
-		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
-	}
+    async loadSettings() {
+        this.settings = Object.assign(
+            {},
+            DEFAULT_SETTINGS,
+            await this.loadData(),
+        );
+    }
 
-	async saveSettings() {
-		await this.saveData(this.settings);
-	}
+    async saveSettings() {
+        await this.saveData(this.settings);
+    }
 }

--- a/src/models/BaseModel.ts
+++ b/src/models/BaseModel.ts
@@ -1,11 +1,13 @@
-import { TFile } from "obsidian";
-import { FileModel } from "./FileModel";
-import { YamlKeyMap } from "src/types/YamlKeyMap";
+import { TFile } from 'obsidian';
+import { FileModel } from './FileModel';
+import { YamlKeyMap } from 'src/types/YamlKeyMap';
 
 export default class BaseModel<T extends object> extends FileModel<T> {
-
-    constructor(file: TFile | undefined, ctor: new (data?: Partial<T>) => T, yamlKeyMap: YamlKeyMap | undefined) {
+    constructor(
+        file: TFile | undefined,
+        ctor: new (data?: Partial<T>) => T,
+        yamlKeyMap: YamlKeyMap | undefined,
+    ) {
         super(file, ctor, yamlKeyMap);
     }
-
 }

--- a/src/models/DocumentModel.ts
+++ b/src/models/DocumentModel.ts
@@ -1,13 +1,16 @@
 // Note: DocumentModel class
 
-import { TFile } from "obsidian";
-import { FileModel } from "./FileModel";
-import IPrjModel from "../interfaces/IPrjModel";
-import DocumentData from "../types/DocumentData";
-import Global from "../classes/Global";
-import Helper from "../libs/Helper";
+import { TFile } from 'obsidian';
+import { FileModel } from './FileModel';
+import IPrjModel from '../interfaces/IPrjModel';
+import DocumentData from '../types/DocumentData';
+import Global from '../classes/Global';
+import Helper from '../libs/Helper';
 
-export class DocumentModel extends FileModel<DocumentData> implements IPrjModel<DocumentData> {
+export class DocumentModel
+    extends FileModel<DocumentData>
+    implements IPrjModel<DocumentData>
+{
     private fileCache = Global.getInstance().fileCache;
     private _relatedFiles: DocumentModel[] | null | undefined = undefined;
 
@@ -17,8 +20,7 @@ export class DocumentModel extends FileModel<DocumentData> implements IPrjModel<
 
         if (tags && typeof tags === 'string') {
             formattedTags = [tags];
-        }
-        else if (Array.isArray(tags)) {
+        } else if (Array.isArray(tags)) {
             formattedTags = [...tags];
         }
 
@@ -43,31 +45,46 @@ export class DocumentModel extends FileModel<DocumentData> implements IPrjModel<
         if (this._relatedFiles === undefined) {
             this._relatedFiles = [];
             const relatedFiles = this.data.relatedFiles;
+
             if (relatedFiles) {
                 relatedFiles.map((relatedFile) => {
-                    const wikilinkData = Helper.extractDataFromWikilink(relatedFile);
-                    const mdFilename = wikilinkData.basename ? `${wikilinkData.basename}.md` : "";
-                    const file = this.fileCache.findFileByLinkText(mdFilename, this.file.path);
+                    const wikilinkData =
+                        Helper.extractDataFromWikilink(relatedFile);
+
+                    const mdFilename = wikilinkData.basename
+                        ? `${wikilinkData.basename}.md`
+                        : '';
+
+                    const file = this.fileCache.findFileByLinkText(
+                        mdFilename,
+                        this.file.path,
+                    );
+
                     if (file instanceof TFile && file.path !== this.file.path) {
                         this._relatedFiles?.push(new DocumentModel(file));
                     }
+
                     return null;
                 });
-            } else { this._relatedFiles = null; }
+            } else {
+                this._relatedFiles = null;
+            }
         }
+
         return this._relatedFiles;
     }
 
     public override toString(): string {
-        let allText = this.data.title ?? "";
-        allText += this.data.description ?? "";
-        allText += this.data.date ?? "";
-        allText += this.data.dateOfDelivery ?? "";
-        allText += this.data.file ?? "";
-        allText += this.data.tags ?? "";
-        allText += this.data.sender ?? "";
-        allText += this.data.recipient ?? "";
-        allText += this.data.relatedFiles ?? "";
+        let allText = this.data.title ?? '';
+        allText += this.data.description ?? '';
+        allText += this.data.date ?? '';
+        allText += this.data.dateOfDelivery ?? '';
+        allText += this.data.file ?? '';
+        allText += this.data.tags ?? '';
+        allText += this.data.sender ?? '';
+        allText += this.data.recipient ?? '';
+        allText += this.data.relatedFiles ?? '';
+
         return allText;
     }
 
@@ -92,8 +109,8 @@ export class DocumentModel extends FileModel<DocumentData> implements IPrjModel<
     }
 
     public getCorospondingSymbol(): string {
-        if (this.data.type === "Metadata") {
-            if (this.data.subType === "Cluster") {
+        if (this.data.type === 'Metadata') {
+            if (this.data.subType === 'Cluster') {
                 return this.global.settings.documentSettings.clusterSymbol;
             } else if (this.data.hide) {
                 return this.global.settings.documentSettings.hideSymbol;
@@ -101,7 +118,8 @@ export class DocumentModel extends FileModel<DocumentData> implements IPrjModel<
                 return this.global.settings.documentSettings.symbol;
             }
         }
-        return "x-circle";
+
+        return 'x-circle';
     }
 
     /**
@@ -110,7 +128,7 @@ export class DocumentModel extends FileModel<DocumentData> implements IPrjModel<
      * @deprecated Use `data.description` instead.
      */
     public getDescription(): string {
-        return this.data.description ?? "";
+        return this.data.description ?? '';
     }
 
     /**
@@ -118,16 +136,22 @@ export class DocumentModel extends FileModel<DocumentData> implements IPrjModel<
      * @returns State of the document.
      * E.g. `Input` if the document is addressed to the user or `Output` if it comes from the user. Otherwise `null`.
      */
-    public getInputOutputState(): null | "Input" | "Output" {
+    public getInputOutputState(): null | 'Input' | 'Output' {
         const username = this.global.settings.user.name;
         const shortUsername = this.global.settings.user.shortName;
+
         if (this.data && (this.data.sender || this.data.recipient)) {
-            if (this.data.sender === username || this.data.sender === shortUsername) {
-                return "Output";
-            } else if (this.data.recipient === username || this.data.recipient === shortUsername) {
-                return "Input";
-            }
-            else {
+            if (
+                this.data.sender === username ||
+                this.data.sender === shortUsername
+            ) {
+                return 'Output';
+            } else if (
+                this.data.recipient === username ||
+                this.data.recipient === shortUsername
+            ) {
+                return 'Input';
+            } else {
                 return null;
             }
         } else {
@@ -141,29 +165,42 @@ export class DocumentModel extends FileModel<DocumentData> implements IPrjModel<
      */
     public getLinkedFile(): TFile | undefined {
         const fileLinkData = Helper.extractDataFromWikilink(this.data.file);
-        const file = this.fileCache.findFileByLinkText(fileLinkData.filename ?? "", this.file.path);
+
+        const file = this.fileCache.findFileByLinkText(
+            fileLinkData.filename ?? '',
+            this.file.path,
+        );
+
         if (file instanceof TFile) {
             return file;
         } else {
             this.logger.warn(`No files found for ${fileLinkData.filename}`);
+
             return undefined;
         }
     }
 
-
     /**
      * Sets the linked file for the document.
-     * 
+     *
      * @param file The TFile object representing the linked file.
      * @param path The optional path to override the file's path.
      * @remarks - This function sets the `file` property of the document to the wikilink of the file.
      * - If no file is provided, the function will return.
      */
-    public setLinkedFile(file: TFile | undefined, path?: string): string | undefined {
+    public setLinkedFile(
+        file: TFile | undefined,
+        path?: string,
+    ): string | undefined {
         if (!file || !(file instanceof TFile)) return;
-        const linktext = this.global.app.metadataCache.fileToLinktext(file, path ? path : this.file.path);
+
+        const linktext = this.global.app.metadataCache.fileToLinktext(
+            file,
+            path ? path : this.file.path,
+        );
         const link = `[[${linktext}]]`;
         this.data.file = link;
+
         return link;
     }
 
@@ -177,12 +214,10 @@ export class DocumentModel extends FileModel<DocumentData> implements IPrjModel<
 
         if (tags && typeof tags === 'string') {
             formattedTags = [tags];
-        }
-        else if (Array.isArray(tags)) {
+        } else if (Array.isArray(tags)) {
             formattedTags = [...tags];
         }
 
         return formattedTags;
     }
 }
-

--- a/src/models/NoteModel.ts
+++ b/src/models/NoteModel.ts
@@ -1,12 +1,15 @@
 // Note: DocumentModel class
 
-import { TFile } from "obsidian";
-import { FileModel } from "./FileModel";
-import IPrjModel from "../interfaces/IPrjModel";
-import Global from "../classes/Global";
-import NoteData from "src/types/NoteData";
+import { TFile } from 'obsidian';
+import { FileModel } from './FileModel';
+import IPrjModel from '../interfaces/IPrjModel';
+import Global from '../classes/Global';
+import NoteData from 'src/types/NoteData';
 
-export class NoteModel extends FileModel<NoteData> implements IPrjModel<NoteData> {
+export class NoteModel
+    extends FileModel<NoteData>
+    implements IPrjModel<NoteData>
+{
     private fileCache = Global.getInstance().fileCache;
 
     get tags(): string[] {
@@ -15,8 +18,7 @@ export class NoteModel extends FileModel<NoteData> implements IPrjModel<NoteData
 
         if (tags && typeof tags === 'string') {
             formattedTags = [tags];
-        }
-        else if (Array.isArray(tags)) {
+        } else if (Array.isArray(tags)) {
             formattedTags = [...tags];
         }
 
@@ -38,10 +40,11 @@ export class NoteModel extends FileModel<NoteData> implements IPrjModel<NoteData
     }
 
     public override toString(): string {
-        let allText = this.data.title ?? "";
-        allText += this.data.description ?? "";
-        allText += this.data.date ?? "";
-        allText += this.data.tags ?? "";
+        let allText = this.data.title ?? '';
+        allText += this.data.description ?? '';
+        allText += this.data.date ?? '';
+        allText += this.data.tags ?? '';
+
         return allText;
     }
 
@@ -75,12 +78,10 @@ export class NoteModel extends FileModel<NoteData> implements IPrjModel<NoteData
 
         if (tags && typeof tags === 'string') {
             formattedTags = [tags];
-        }
-        else if (Array.isArray(tags)) {
+        } else if (Array.isArray(tags)) {
             formattedTags = [...tags];
         }
 
         return formattedTags;
     }
 }
-

--- a/src/models/PrjTaskManagementModel.ts
+++ b/src/models/PrjTaskManagementModel.ts
@@ -1,25 +1,25 @@
-import { TFile, moment } from "obsidian";
-import { FileModel } from "./FileModel";
-import IPrjModel from "../interfaces/IPrjModel";
-import IPrjData from "../interfaces/IPrjData";
-import IPrjTaskManagement from "../interfaces/IPrjTaskManagement";
-import PrjTypes, { Status } from "src/types/PrjTypes";
-import API from "src/classes/API";
-import TaskData from "src/types/TaskData";
-import ProjectData from "src/types/ProjectData";
-import TopicData from "src/types/TopicData";
+import { TFile, moment } from 'obsidian';
+import { FileModel } from './FileModel';
+import IPrjModel from '../interfaces/IPrjModel';
+import IPrjData from '../interfaces/IPrjData';
+import IPrjTaskManagement from '../interfaces/IPrjTaskManagement';
+import PrjTypes, { Status } from 'src/types/PrjTypes';
+import API from 'src/classes/API';
+import TaskData from 'src/types/TaskData';
+import ProjectData from 'src/types/ProjectData';
+import TopicData from 'src/types/TopicData';
 
-
-export class PrjTaskManagementModel<T extends IPrjData & IPrjTaskManagement> extends FileModel<T> implements IPrjModel<T> {
-
+export class PrjTaskManagementModel<T extends IPrjData & IPrjTaskManagement>
+    extends FileModel<T>
+    implements IPrjModel<T>
+{
     get tags(): string[] {
         const tags = this.data.tags;
         let formattedTags: string[] = [];
 
         if (tags && typeof tags === 'string') {
             formattedTags = [tags];
-        }
-        else if (Array.isArray(tags)) {
+        } else if (Array.isArray(tags)) {
             formattedTags = [...tags];
         }
 
@@ -41,11 +41,12 @@ export class PrjTaskManagementModel<T extends IPrjData & IPrjTaskManagement> ext
     }
 
     public override toString(): string {
-        let allText = this.data.title ?? "";
-        allText += this.data.description ?? "";
-        allText += this.data.status ?? "";
-        allText += this.data.due ?? "";
-        allText += this.data.tags ?? "";
+        let allText = this.data.title ?? '';
+        allText += this.data.description ?? '';
+        allText += this.data.status ?? '';
+        allText += this.data.due ?? '';
+        allText += this.data.tags ?? '';
+
         return allText;
     }
 
@@ -70,44 +71,50 @@ export class PrjTaskManagementModel<T extends IPrjData & IPrjTaskManagement> ext
      */
     public changeStatus(newStatus: unknown): void {
         const status = PrjTypes.isValidStatus(newStatus);
+
         if (!status) return;
+
         if (this.data.status !== status) {
             let internalTransaction = false;
+
             if (!this.isTransactionActive) {
                 this.startTransaction();
                 internalTransaction = true;
             }
             this.data.status = status;
             this.addHistoryEntry(status);
-            if (internalTransaction)
-                this.finishTransaction();
+
+            if (internalTransaction) this.finishTransaction();
         }
     }
 
     public get urgency(): number {
-        return API.prjTaskManagementModel.calculateUrgency(this as (PrjTaskManagementModel<TaskData | TopicData | ProjectData>));
+        return API.prjTaskManagementModel.calculateUrgency(
+            this as PrjTaskManagementModel<TaskData | TopicData | ProjectData>,
+        );
     }
 
     /**
      * Add a new history entry to the model.
-     * @param status The status to add to the history. If not provided, the current status of the model will be used. 
+     * @param status The status to add to the history. If not provided, the current status of the model will be used.
      * @remarks - This function will not start or finish a transaction.
      * - If no status is provided and the model has no status, an error will be logged and the function will return.
      */
     private addHistoryEntry(status?: Status | undefined): void {
         if (!status) {
-            if (this.data.status)
-                status = this.data.status;
+            if (this.data.status) status = this.data.status;
             else {
-                this.logger.error("No status aviable to add to history");
+                this.logger.error('No status aviable to add to history');
+
                 return;
             }
         }
-        if (!this.data.history)
-            this.data.history = [];
+
+        if (!this.data.history) this.data.history = [];
+
         this.data.history.push({
             status: status,
-            date: moment().format("YYYY-MM-DDTHH:mm")
+            date: moment().format('YYYY-MM-DDTHH:mm'),
         });
     }
 
@@ -121,12 +128,10 @@ export class PrjTaskManagementModel<T extends IPrjData & IPrjTaskManagement> ext
 
         if (tags && typeof tags === 'string') {
             formattedTags = [tags];
-        }
-        else if (Array.isArray(tags)) {
+        } else if (Array.isArray(tags)) {
             formattedTags = [...tags];
         }
 
         return formattedTags;
     }
-
 }

--- a/src/models/ProjectModel.ts
+++ b/src/models/ProjectModel.ts
@@ -1,11 +1,9 @@
-import { TFile } from "obsidian";
-import ProjectData from "src/types/ProjectData";
-import { PrjTaskManagementModel } from "./PrjTaskManagementModel";
+import { TFile } from 'obsidian';
+import ProjectData from 'src/types/ProjectData';
+import { PrjTaskManagementModel } from './PrjTaskManagementModel';
 
 export class ProjectModel extends PrjTaskManagementModel<ProjectData> {
-
     constructor(file: TFile | undefined) {
         super(file, ProjectData);
     }
-
 }

--- a/src/models/StaticHelper/StaticPrjTaskManagementModel.ts
+++ b/src/models/StaticHelper/StaticPrjTaskManagementModel.ts
@@ -1,16 +1,15 @@
-import { TFile } from "obsidian";
-import Global from "src/classes/Global";
-import PrjTypes, { Status } from "src/types/PrjTypes";
-import ProjectData from "src/types/ProjectData";
-import TaskData from "src/types/TaskData";
-import TopicData from "src/types/TopicData";
-import { PrjTaskManagementModel } from "../PrjTaskManagementModel";
-import { ProjectModel } from "../ProjectModel";
-import { TaskModel } from "../TaskModel";
-import { TopicModel } from "../TopicModel";
-import path from "path";
-import Logging from "src/classes/Logging";
-
+import { TFile } from 'obsidian';
+import Global from 'src/classes/Global';
+import PrjTypes, { Status } from 'src/types/PrjTypes';
+import ProjectData from 'src/types/ProjectData';
+import TaskData from 'src/types/TaskData';
+import TopicData from 'src/types/TopicData';
+import { PrjTaskManagementModel } from '../PrjTaskManagementModel';
+import { ProjectModel } from '../ProjectModel';
+import { TaskModel } from '../TaskModel';
+import { TopicModel } from '../TopicModel';
+import path from 'path';
+import Logging from 'src/classes/Logging';
 
 /**
  * Represents a static helper class for managing project task models.
@@ -21,24 +20,35 @@ export class StaticPrjTaskManagementModel {
      * @param file The file for which to retrieve the corresponding model.
      * @returns The corresponding model if found, otherwise undefined.
      */
-    public static getCorospondingModel(file: TFile): (PrjTaskManagementModel<TaskData | TopicData | ProjectData>) | undefined {
+    public static getCorospondingModel(
+        file: TFile,
+    ): PrjTaskManagementModel<TaskData | TopicData | ProjectData> | undefined {
         const entry = Global.getInstance().metadataCache.getEntry(file);
+
         if (!entry) {
             return undefined;
         }
-        const type = entry.metadata.frontmatter?.type
+        const type = entry.metadata.frontmatter?.type;
+
         if (!type) {
             return undefined;
         }
+
         switch (type) {
-            case "Topic":
-                return new TopicModel(entry.file) as PrjTaskManagementModel<TopicData>;
+            case 'Topic':
+                return new TopicModel(
+                    entry.file,
+                ) as PrjTaskManagementModel<TopicData>;
                 break;
-            case "Project":
-                return new ProjectModel(entry.file) as PrjTaskManagementModel<ProjectData>;
+            case 'Project':
+                return new ProjectModel(
+                    entry.file,
+                ) as PrjTaskManagementModel<ProjectData>;
                 break;
-            case "Task":
-                return new TaskModel(entry.file) as PrjTaskManagementModel<TaskData>;
+            case 'Task':
+                return new TaskModel(
+                    entry.file,
+                ) as PrjTaskManagementModel<TaskData>;
                 break;
             default:
                 return undefined;
@@ -62,11 +72,14 @@ export class StaticPrjTaskManagementModel {
      * - Fallback to sorting by last history entry
      * - Fallback to stop sorting
      */
-    public static sortModelsByUrgency(models: (PrjTaskManagementModel<TaskData | TopicData | ProjectData>)[]): void {
+    public static sortModelsByUrgency(
+        models: PrjTaskManagementModel<TaskData | TopicData | ProjectData>[],
+    ): void {
         models.sort((a, b) => {
             // If both are `done`, sort by last history entry
             const aDate = StaticPrjTaskManagementModel.getLastHistoryDate(a);
             const bDate = StaticPrjTaskManagementModel.getLastHistoryDate(b);
+
             if (a.data.status === 'Done' && b.data.status === 'Done') {
                 if (aDate && bDate) {
                     return bDate.getTime() - aDate.getTime();
@@ -77,6 +90,7 @@ export class StaticPrjTaskManagementModel {
             if (a.data.status === 'Done') {
                 return 1;
             }
+
             // If `b` is done, sort it lower
             if (b.data.status === 'Done') {
                 return -1;
@@ -85,13 +99,20 @@ export class StaticPrjTaskManagementModel {
             // Both are not done, sort by urgency
             const aUrgency = StaticPrjTaskManagementModel.calculateUrgency(a);
             const bUrgency = StaticPrjTaskManagementModel.calculateUrgency(b);
+
             if (bUrgency !== aUrgency) {
                 return bUrgency - aUrgency;
             }
 
             // Both have the same urgency, sort by status
-            const aStatus = StaticPrjTaskManagementModel.statusToNumber(a.data.status);
-            const bStatus = StaticPrjTaskManagementModel.statusToNumber(b.data.status);
+            const aStatus = StaticPrjTaskManagementModel.statusToNumber(
+                a.data.status,
+            );
+
+            const bStatus = StaticPrjTaskManagementModel.statusToNumber(
+                b.data.status,
+            );
+
             if (bStatus !== aStatus) {
                 return bStatus - aStatus;
             }
@@ -99,6 +120,7 @@ export class StaticPrjTaskManagementModel {
             // Both have the same status, sort by priority
             const aPrirority = a.data.priority ?? 0;
             const bPrirority = b.data.priority ?? 0;
+
             if (bPrirority !== aPrirority) {
                 return bPrirority - aPrirority;
             }
@@ -114,16 +136,16 @@ export class StaticPrjTaskManagementModel {
     }
 
     /**
-    * Returns the number representation of the status.
-    * @param status The status to convert.
-    * @returns The number representation of the status.
-    * @remarks The number representation is:
-    * - `Active` = 3
-    * - `Waiting` = 2
-    * - `Later` = 1
-    * - `Someday` = 0
-    * - `undefined` = -1
-    */
+     * Returns the number representation of the status.
+     * @param status The status to convert.
+     * @returns The number representation of the status.
+     * @remarks The number representation is:
+     * - `Active` = 3
+     * - `Waiting` = 2
+     * - `Later` = 1
+     * - `Someday` = 0
+     * - `undefined` = -1
+     */
     private static statusToNumber(status: Status | undefined | null): number {
         switch (status) {
             case 'Active':
@@ -151,13 +173,17 @@ export class StaticPrjTaskManagementModel {
      * - Due date is in the next 7 days = 1
      * - Due date is in more the future = 0
      */
-    public static calculateUrgency(model: (PrjTaskManagementModel<TaskData | TopicData | ProjectData>)): number {
+    public static calculateUrgency(
+        model: PrjTaskManagementModel<TaskData | TopicData | ProjectData>,
+    ): number {
         if (!model.data.status || model.data.status === 'Done') {
             return -2;
         }
+
         if (model.data.status === 'Someday') {
             return -1;
         }
+
         if (!model.data.due) {
             return 0;
         }
@@ -168,7 +194,8 @@ export class StaticPrjTaskManagementModel {
         const today = new Date();
         today.setHours(0, 0, 0, 0);
 
-        const differenceInDays = (dueDate.getTime() - today.getTime()) / (1000 * 3600 * 24);
+        const differenceInDays =
+            (dueDate.getTime() - today.getTime()) / (1000 * 3600 * 24);
 
         let urgency = 0;
 
@@ -188,10 +215,17 @@ export class StaticPrjTaskManagementModel {
      * @param model The model to get the last history entry date from.
      * @returns The date of the last history entry.
      */
-    private static getLastHistoryDate(model: (PrjTaskManagementModel<TaskData | TopicData | ProjectData>)): Date | null {
-        if (model.data.history && Array.isArray(model.data.history) && model.data.history.length > 0) {
+    private static getLastHistoryDate(
+        model: PrjTaskManagementModel<TaskData | TopicData | ProjectData>,
+    ): Date | null {
+        if (
+            model.data.history &&
+            Array.isArray(model.data.history) &&
+            model.data.history.length > 0
+        ) {
             const history = model.data.history;
             const lastEntry = history[history.length - 1];
+
             return new Date(lastEntry.date);
         } else {
             return null;
@@ -204,29 +238,32 @@ export class StaticPrjTaskManagementModel {
      */
     public static syncStatusToPath(file: TFile) {
         const model = StaticPrjTaskManagementModel.getCorospondingModel(file);
+
         if (!model) {
             return;
         }
         const status = model.data.status;
+
         if (!status) {
             return;
         }
         const settings = Global.getInstance().settings.prjSettings;
         let parentPath: string | undefined;
         const filename = model.file.name;
+
         if (model.file.parent?.path) {
             switch (model.data.type) {
-                case "Topic":
+                case 'Topic':
                     if (settings.topicFolder) {
                         parentPath = settings.topicFolder;
                     }
                     break;
-                case "Project":
+                case 'Project':
                     if (settings.projectFolder) {
                         parentPath = settings.projectFolder;
                     }
                     break;
-                case "Task":
+                case 'Task':
                     if (settings.taskFolder) {
                         parentPath = settings.taskFolder;
                     }
@@ -238,6 +275,7 @@ export class StaticPrjTaskManagementModel {
 
         if (parentPath) {
             let movePath: string;
+
             if (model.data.status === 'Done') {
                 movePath = path.join(parentPath, 'Archiv', filename);
             } else if (PrjTypes.isValidStatus(model.data.status)) {
@@ -248,11 +286,14 @@ export class StaticPrjTaskManagementModel {
 
             const app = Global.getInstance().app;
             const logger = Logging.getLogger('StaticPrjTaskManagementModel');
+
             if (movePath.replace('\\', '/') !== model.file.path) {
                 logger.debug(`Moving file ${model.file.path} to ${movePath}`);
                 app.vault.rename(model.file, movePath);
             } else {
-                logger.debug(`File ${model.file.path} is already in the correct folder`);
+                logger.debug(
+                    `File ${model.file.path} is already in the correct folder`,
+                );
             }
         }
     }

--- a/src/models/TaskModel.ts
+++ b/src/models/TaskModel.ts
@@ -1,15 +1,16 @@
-import { TFile } from "obsidian";
-import TaskData from "src/types/TaskData";
-import { PrjTaskManagementModel } from "./PrjTaskManagementModel";
-import API from "src/classes/API";
-import ProjectData from "src/types/ProjectData";
-import TopicData from "src/types/TopicData";
-import Tags from "src/libs/Tags";
-import { Status } from "src/types/PrjTypes";
+import { TFile } from 'obsidian';
+import TaskData from 'src/types/TaskData';
+import { PrjTaskManagementModel } from './PrjTaskManagementModel';
+import API from 'src/classes/API';
+import ProjectData from 'src/types/ProjectData';
+import TopicData from 'src/types/TopicData';
+import Tags from 'src/libs/Tags';
+import { Status } from 'src/types/PrjTypes';
 
 export class TaskModel extends PrjTaskManagementModel<TaskData> {
     public get relatedTasks(): TaskModel[] {
-        this._relatedTasks = this._relatedTasks ?? this.getRelatedTasks()
+        this._relatedTasks = this._relatedTasks ?? this.getRelatedTasks();
+
         return this._relatedTasks;
     }
 
@@ -20,24 +21,34 @@ export class TaskModel extends PrjTaskManagementModel<TaskData> {
     }
 
     public override get urgency(): number {
-        return API.prjTaskManagementModel.calculateUrgency(this as (PrjTaskManagementModel<TaskData | TopicData | ProjectData>));
+        return API.prjTaskManagementModel.calculateUrgency(
+            this as PrjTaskManagementModel<TaskData | TopicData | ProjectData>,
+        );
     }
 
     /**private calculateUrgency(): number {
         const taskSiblings = this.getRelatedTasks((status) => status ? status !== 'Done' : false);
     }**/
 
-    private getRelatedTasks(status?: (status: Status | undefined) => boolean): TaskModel[] {
+    private getRelatedTasks(
+        status?: (status: Status | undefined) => boolean,
+    ): TaskModel[] {
         const filesWithSameTags = this.metadataCache.cache.filter((file) => {
-            const fileTags = Tags.getValidTags(file.metadata?.frontmatter?.tags);
+            const fileTags = Tags.getValidTags(
+                file.metadata?.frontmatter?.tags,
+            );
             const thisTags = this.tags;
-            return (fileTags.some((tag) => thisTags.includes(tag)))
-                && (file.file.basename !== this.file.basename)
-                && (file.metadata?.frontmatter?.type === 'Task')
-                && (status ? status(file.metadata?.frontmatter?.status) : true);
+
+            return (
+                fileTags.some((tag) => thisTags.includes(tag)) &&
+                file.file.basename !== this.file.basename &&
+                file.metadata?.frontmatter?.type === 'Task' &&
+                (status ? status(file.metadata?.frontmatter?.status) : true)
+            );
         });
 
         const relatedTasks: TaskModel[] = [];
+
         filesWithSameTags.forEach((file) => {
             if (file instanceof TFile) {
                 relatedTasks.push(new TaskModel(file));

--- a/src/models/TopicModel.ts
+++ b/src/models/TopicModel.ts
@@ -1,11 +1,9 @@
-import { TFile } from "obsidian";
-import TopicData from "src/types/TopicData";
-import { PrjTaskManagementModel } from "./PrjTaskManagementModel";
+import { TFile } from 'obsidian';
+import TopicData from 'src/types/TopicData';
+import { PrjTaskManagementModel } from './PrjTaskManagementModel';
 
 export class TopicModel extends PrjTaskManagementModel<TopicData> {
-
     constructor(file: TFile | undefined) {
         super(file, TopicData);
     }
-
 }

--- a/src/models/TransactionModel.ts
+++ b/src/models/TransactionModel.ts
@@ -1,7 +1,7 @@
 // Note: TransactionModel class
 
-import Global from "src/classes/Global";
-import Logging from "src/classes/Logging";
+import Global from 'src/classes/Global';
+import Logging from 'src/classes/Logging';
 
 /**
  * A class that handles transactions.
@@ -36,7 +36,6 @@ export class TransactionModel<T> {
         }
     }
 
-
     /**
      * Sets the callback function for writing changes to the transaction model.
      * @param writeChanges The callback function that takes an update of type T and returns a Promise that resolves when the changes are written.
@@ -45,7 +44,14 @@ export class TransactionModel<T> {
      */
     public setWriteChanges(writeChanges: (update: T) => Promise<void>) {
         this.writeChanges = writeChanges;
-        if (this.isTransactionActive && !(Object.keys(this.changes).length === 0 && this.changes.constructor === Object)) {
+
+        if (
+            this.isTransactionActive &&
+            !(
+                Object.keys(this.changes).length === 0 &&
+                this.changes.constructor === Object
+            )
+        ) {
             this.finishTransaction();
         } else if (this.isTransactionActive) {
             this.abortTransaction();
@@ -61,11 +67,20 @@ export class TransactionModel<T> {
     protected callWriteChanges(update: T = this.changes as T): boolean {
         if (this.writeChanges) {
             this.writeChanges(update)
-                .then(() => { this.logger.debug("Changes written to file"); })
-                .catch((error) => { this.logger.error("Failed to write changes to file:", error); })
+                .then(() => {
+                    this.logger.debug('Changes written to file');
+                })
+                .catch((error) => {
+                    this.logger.error(
+                        'Failed to write changes to file:',
+                        error,
+                    );
+                });
+
             return true;
         } else {
-            this.logger.debug("No writeChanges function available");
+            this.logger.debug('No writeChanges function available');
+
             return false;
         }
     }
@@ -77,6 +92,7 @@ export class TransactionModel<T> {
     public startTransaction(): void {
         if (this.isTransactionActive) {
             this.logger.warn('Transaction already active');
+
             return;
         }
         this.transactionActive = true;
@@ -91,6 +107,7 @@ export class TransactionModel<T> {
     public finishTransaction(): void {
         if (!this.isTransactionActive) {
             this.logger.warn('No transaction active');
+
             return;
         }
         const writeChanges = this.callWriteChanges();
@@ -106,9 +123,11 @@ export class TransactionModel<T> {
     public abortTransaction(): void {
         if (!this.isTransactionActive) {
             this.logger.warn('No transaction active');
+
             return;
         } else if (!this.writeChanges) {
-            this.logger.warn("No writeChanges function available");
+            this.logger.warn('No writeChanges function available');
+
             return;
         }
         this.changes = {};


### PR DESCRIPTION
- Added Prettier as a new dev dependency along with the 'eslint-plugin-prettier' plugin
- Configured ESLint to treat Prettier issues as errors
- Created a '.prettierrc.json' file to specify Prettier formatting rules
- Upgraded the version of the 'obsidian-sample-plugin' to reflect new changes