### PR TITLE
Feature/sync-tsk-manahment-title-with-filename

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -52,6 +52,21 @@ export default class Prj extends Plugin {
         // Get Metadata File Context Menu & Command
         GetMetadata.getInstance();
 
+        // Register Commands and Events
+        this.registerCommandsAndEvents();
+
+        /**
+         * Run rebuild active view after 500ms
+         * This is a workaround for the problem
+         * that the plugin is not loaded when the
+         * start page is loaded.
+         */
+        setTimeout(() => {
+            Helper.rebuildActiveView();
+        }, 500);
+    }
+
+    private registerCommandsAndEvents(): void {
         // Create New Metadata File Command
         CreateNewMetadataModal.registerCommand();
 
@@ -70,6 +85,14 @@ export default class Prj extends Plugin {
             'prj-task-management-changed-status-event',
             (file) => {
                 StaticPrjTaskManagementModel.syncStatusToPath(file);
+            },
+        );
+
+        //Register event on `tsk-file` change..
+        Global.getInstance().metadataCache.on(
+            'prj-task-management-file-changed-event',
+            (file) => {
+                StaticPrjTaskManagementModel.syncTitleToFilename(file);
             },
         );
 
@@ -92,16 +115,6 @@ export default class Prj extends Plugin {
                 Helper.rebuildActiveView();
             },
         });
-
-        /**
-         * Run rebuild active view after 500ms
-         * This is a workaround for the problem
-         * that the plugin is not loaded when the
-         * start page is loaded.
-         */
-        setTimeout(() => {
-            Helper.rebuildActiveView();
-        }, 500);
     }
 
     onunload() {

--- a/src/models/StaticHelper/StaticDocumentModel.ts
+++ b/src/models/StaticHelper/StaticDocumentModel.ts
@@ -175,7 +175,8 @@ export class StaticDocumentModel {
             logger.trace(
                 `Moving file '${document.file.path}' to '${desiredFilePath}'`,
             );
-            await app.vault.rename(document.file, desiredFilePath);
+            // fileManager.renameFile does autorenaming internal links
+            await app.fileManager.renameFile(document.file, desiredFilePath);
         } else {
             logger.trace(
                 `File '${document.file.path}' is already in the correct folder`,
@@ -232,8 +233,8 @@ export class StaticDocumentModel {
             logger.trace(
                 `Moving file '${pdfFile.path}' to '${desiredPdfFilePath}'`,
             );
-            await app.vault.rename(pdfFile, desiredPdfFilePath);
-            document.setLinkedFile(pdfFile);
+            // fileManager.renameFile does autorenaming internal links
+            await app.fileManager.renameFile(pdfFile, desiredPdfFilePath);
         }
     }
 }


### PR DESCRIPTION
Introduced a method to synchronize file names with task titles in the project management helper, ensuring consistency between the displayed task name and its associated file name. The new functionality checks if the task's title differs from the file name and if so, renames the file using a sanitized version of the task title while maintaining the file extension. This update uses the application's file manager's rename function, which handles internal link updates automatically, offering an improvement over the previous direct vault renaming approach. The change includes appropriate logging for debugging purposes.