### PR TITLE
Feature/implement-file-renaming-in-filemodel

### DIFF
--- a/src/classes/API.ts
+++ b/src/classes/API.ts
@@ -2,8 +2,8 @@
 import Global from 'src/classes/Global';
 import Helper from 'src/libs/Helper';
 import { DocumentModel } from 'src/models/DocumentModel';
+import { NoteModel } from 'src/models/NoteModel';
 import { PrjTaskManagementModel } from 'src/models/PrjTaskManagementModel';
-import { StaticNoteModel } from 'src/models/StaticHelper/StaticNoteModel';
 
 export default class API {
     public static get global(): Global {
@@ -11,6 +11,6 @@ export default class API {
     }
     public static documentModel = DocumentModel;
     public static prjTaskManagementModel = PrjTaskManagementModel;
-    private static noteModel = StaticNoteModel;
+    public static noteModel = NoteModel;
     public static helper = Helper;
 }

--- a/src/libs/Modals/CreateNewMetadataModal.ts
+++ b/src/libs/Modals/CreateNewMetadataModal.ts
@@ -13,7 +13,6 @@ import Helper from '../Helper';
 import PrjTypes, { FileSubType } from 'src/types/PrjTypes';
 import API from 'src/classes/API';
 import { TFile } from 'obsidian';
-import { Path } from 'src/classes/Path';
 import Logging from 'src/classes/Logging';
 
 /**
@@ -157,11 +156,7 @@ export default class CreateNewMetadataModal extends BaseModalForm {
             const newFileName =
                 API.documentModel.generateMetadataFilename(document);
 
-            const file = await this.app.vault.create(
-                Path.join(folder, `${newFileName}.md`),
-                template,
-            );
-            document.file = file;
+            await document.createFile(folder, newFileName, template);
         } else {
             // Existing file, rename it properly
             await API.documentModel.syncMetadataToFile(document.file);

--- a/src/libs/Modals/CreateNewNoteModal.ts
+++ b/src/libs/Modals/CreateNewNoteModal.ts
@@ -12,9 +12,8 @@ import Helper from '../Helper';
 import { TFile } from 'obsidian';
 import { NoteModel } from 'src/models/NoteModel';
 import NoteData from 'src/types/NoteData';
-import { StaticNoteModel } from 'src/models/StaticHelper/StaticNoteModel';
-import { Path } from 'src/classes/Path';
 import Logging from 'src/classes/Logging';
+import API from 'src/classes/API';
 
 /**
  * Modal to create a new metadata file
@@ -142,18 +141,13 @@ export default class CreateNewNoteModal extends BaseModalForm {
                 }
             }
 
-            const newFileName = StaticNoteModel.generateFilename(note);
+            const newFileName = API.noteModel.generateFilename(note);
 
-            const file = await this.app.vault.create(
-                Path.join(folder, `${newFileName}.md`),
-                template,
-            );
-            note.file = file;
+            await note.createFile(folder, newFileName, template);
         } else {
             // Existing file, rename it properly
-            const newFileName = StaticNoteModel.generateFilename(note);
-            const newFilePath = Path.join(folder, `${newFileName}.md`);
-            await this.app.fileManager.renameFile(note.file, newFilePath);
+            const newFileName = API.noteModel.generateFilename(note);
+            note.moveFile(folder, newFileName);
         }
 
         return note;

--- a/src/libs/Modals/CreateNewTaskManagementModal.ts
+++ b/src/libs/Modals/CreateNewTaskManagementModal.ts
@@ -243,8 +243,7 @@ export default class CreateNewTaskManagementModal extends BaseModalForm {
             }
         }
 
-        const file = await this.app.vault.create(modelFile.fullPath, template);
-        model.file = file;
+        await model.createFile(modelFile.fullPath, template);
 
         return model;
     }

--- a/src/models/NoteModel.ts
+++ b/src/models/NoteModel.ts
@@ -7,6 +7,8 @@ import Global from '../classes/Global';
 import NoteData from 'src/types/NoteData';
 import Logging from 'src/classes/Logging';
 import { ILogger } from 'src/interfaces/ILogger';
+import Helper from 'src/libs/Helper';
+import Tags from 'src/libs/Tags';
 
 export class NoteModel
     extends FileModel<NoteData>
@@ -87,4 +89,42 @@ export class NoteModel
 
         return formattedTags;
     }
+
+    /**
+     * Static API for the NoteModel class.
+     */
+    //#region Static API
+    /**
+     * Generates a filename based on the provided NoteModel.
+     *
+     * @param model The NoteModel object used to generate the filename.
+     * @returns The generated filename as a string.
+     */
+    public static generateFilename(model: NoteModel): string {
+        const newFileName: string[] = [];
+
+        if (model.data.date) {
+            newFileName.push(
+                `${Helper.formatDate(model.data.date, Global.getInstance().settings.dateFormat)}`,
+            );
+        }
+
+        if (model.data.tags) {
+            const tags = Tags.getValidTags(model.data.tags);
+            const firstTag = tags.first();
+
+            if (firstTag && firstTag !== undefined) {
+                const seperateTags = Tags.getTagElements(firstTag);
+                const lastTagElement = seperateTags.last();
+                lastTagElement && newFileName.push(lastTagElement);
+            }
+        }
+
+        if (model.data.title) {
+            newFileName.push(model.data.title);
+        }
+
+        return Helper.sanitizeFilename(newFileName.join(' - '));
+    }
+    //#endregion
 }

--- a/src/models/PrjTaskManagementModel.ts
+++ b/src/models/PrjTaskManagementModel.ts
@@ -13,7 +13,6 @@ import Tags from 'src/libs/Tags';
 import Helper from 'src/libs/Helper';
 import Global from 'src/classes/Global';
 import { Path } from 'src/classes/Path';
-import FileManager, { Filename } from 'src/libs/FileManager';
 
 export class PrjTaskManagementModel<T extends IPrjData & IPrjTaskManagement>
     extends FileModel<T>
@@ -461,9 +460,7 @@ export class PrjTaskManagementModel<T extends IPrjData & IPrjTaskManagement>
             return;
         }
 
-        const filename: Filename = new Filename(automaticFilename, 'md');
-
-        FileManager.renameFile(file, filename, model.writeChangesPromise);
+        model.renameFile(automaticFilename);
     }
 
     /**
@@ -483,7 +480,6 @@ export class PrjTaskManagementModel<T extends IPrjData & IPrjTaskManagement>
         }
         const settings = Global.getInstance().settings.prjSettings;
         let parentPath: string | undefined;
-        const filename = model.file.name;
 
         if (model.file.parent?.path) {
             switch (model.data.type) {
@@ -511,25 +507,14 @@ export class PrjTaskManagementModel<T extends IPrjData & IPrjTaskManagement>
             let movePath: string;
 
             if (model.data.status === 'Done') {
-                movePath = Path.join(parentPath, 'Archiv', filename);
+                movePath = Path.join(parentPath, 'Archiv');
             } else if (PrjTypes.isValidStatus(model.data.status)) {
-                movePath = Path.join(parentPath, filename);
+                movePath = parentPath;
             } else {
                 return;
             }
 
-            const app = Global.getInstance().app;
-            const logger = Logging.getLogger('StaticPrjTaskManagementModel');
-
-            if (movePath !== model.file.path) {
-                logger.debug(`Moving file ${model.file.path} to ${movePath}`);
-                // fileManager.renameFile does autorenaming internal links
-                app.fileManager.renameFile(model.file, movePath);
-            } else {
-                logger.debug(
-                    `File ${model.file.path} is already in the correct folder`,
-                );
-            }
+            model.moveFile(movePath);
         }
     }
 

--- a/src/models/StaticHelper/StaticNoteModel.ts
+++ b/src/models/StaticHelper/StaticNoteModel.ts
@@ -5,6 +5,7 @@ import Tags from 'src/libs/Tags';
 
 /**
  * Static API for StaticNoteModel
+ * @deprecated Use NoteModel instead.
  */
 export class StaticNoteModel {
     /**
@@ -12,6 +13,7 @@ export class StaticNoteModel {
      *
      * @param model The NoteModel object used to generate the filename.
      * @returns The generated filename as a string.
+     * @deprecated Use NoteModel.generateFilename instead.
      */
     public static generateFilename(model: NoteModel): string {
         const newFileName: string[] = [];

--- a/src/models/TransactionModel.ts
+++ b/src/models/TransactionModel.ts
@@ -30,7 +30,7 @@ export class TransactionModel<T> {
      * A promise that resolves when the changes are written to the file.
      */
     private _writeChangesPromise: Promise<void> | undefined;
-    public get writeChangesPromise(): Promise<void> | undefined {
+    protected get writeChangesPromise(): Promise<void> | undefined {
         return this._writeChangesPromise;
     }
     private _transactionActive = false;


### PR DESCRIPTION
Centralized common file operations such as creation, renaming, and moving across various models and modals. Replaced direct usage of `app.vault` and `app.fileManager` methods with model-specific methods like `createFile`, `renameFile`, and `moveFile` to encapsulate file handling logic within the models, leading to cleaner, more maintainable code structures. Eliminated redundant path construction using `Path.join` by incorporating these operations into the file methods, simplifying the codebase.