### PR TITLE
Add coverage config, tag interfaces, and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ Projekt.txt
 diff_output.txt
 
 .VSCodeCounter
+
+coverage/*

--- a/jest.config.coverage.js
+++ b/jest.config.coverage.js
@@ -8,6 +8,10 @@ module.exports = {
     collectCoverage: true,
     coverageDirectory: 'coverage',
     coverageReporters: ['text', 'lcov'],
+    collectCoverageFrom: [
+        'src/**/*.{ts,tsx}',
+        '!src/**/*.d.ts'
+    ],
     coverageThreshold: {
         global: {
             branches: 80,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "obsidian-prj-plugin",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-prj-plugin",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "crypto-js": "^4.2.0",
         "eslint-plugin-prettier": "^5.1.3",
+        "jest-environment-jsdom": "^29.7.0",
         "js-yaml": "^4.1.0",
         "remark": "^15.0.1",
         "remark-parse": "^11.0.0",
@@ -86,7 +87,6 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.6.tgz",
       "integrity": "sha512-ZJhac6FkEd1yhG2AHOmfcXG4ceoLltoCVJjN5XsWN9BifBQr+cHJbWi0h68HZuSORq+3WtJ2z0hwF2NG1b5kcA==",
-      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.24.6",
         "picocolors": "^1.0.0"
@@ -304,7 +304,6 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.6.tgz",
       "integrity": "sha512-4yA7s865JHaqUdRbnaxarZREuPTHrjpDT+pXoAZ1yhyo6uFnIEpS8VMu16siFOHDpZNKYv5BObhsB//ycbICyw==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -335,7 +334,6 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.6.tgz",
       "integrity": "sha512-2YnuOp4HAk2BsBrJJvYCbItHx0zWscI1C3zgWkz+wDyD9I7GIVrfnLyrR4Y1VR+7p+chAEcrgRQYZAGIKMV7vQ==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.24.6",
         "chalk": "^2.4.2",
@@ -350,7 +348,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -362,7 +359,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -376,7 +372,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -384,14 +379,12 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -400,7 +393,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -409,7 +401,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -1322,7 +1313,6 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
       "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
-      "dev": true,
       "dependencies": {
         "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -1362,7 +1352,6 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
       "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
-      "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@sinonjs/fake-timers": "^10.0.2",
@@ -1447,7 +1436,6 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
       "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -1549,7 +1537,6 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
       "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1698,14 +1685,12 @@
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-      "dev": true
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-      "dev": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -1714,9 +1699,16 @@
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
       "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
-      "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -1825,14 +1817,12 @@
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
-      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-      "dev": true
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
       "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
-      "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -1841,7 +1831,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
       "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
-      "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
@@ -1861,6 +1850,16 @@
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true
+    },
+    "node_modules/@types/jsdom": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -1884,8 +1883,7 @@
     "node_modules/@types/node": {
       "version": "16.18.97",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.97.tgz",
-      "integrity": "sha512-4muilE1Lbfn57unR+/nT9AFjWk0MtWi5muwCEJqnOvfRQDbSfLCUdN7vCIg8TYuaANfhLOV85ve+FNpiUsbSRg==",
-      "dev": true
+      "integrity": "sha512-4muilE1Lbfn57unR+/nT9AFjWk0MtWi5muwCEJqnOvfRQDbSfLCUdN7vCIg8TYuaANfhLOV85ve+FNpiUsbSRg=="
     },
     "node_modules/@types/semver": {
       "version": "7.5.8",
@@ -1896,8 +1894,7 @@
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
-      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-      "dev": true
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="
     },
     "node_modules/@types/tern": {
       "version": "0.23.9",
@@ -1908,6 +1905,11 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
+    },
     "node_modules/@types/unist": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
@@ -1917,7 +1919,6 @@
       "version": "17.0.32",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
       "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-      "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -1925,8 +1926,7 @@
     "node_modules/@types/yargs-parser": {
       "version": "21.0.3",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
-      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-      "dev": true
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
@@ -2122,6 +2122,12 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "peer": true
     },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "deprecated": "Use your platform's native atob() and btoa() methods instead"
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -2145,6 +2151,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "dependencies": {
+        "acorn": "^8.1.0",
+        "acorn-walk": "^8.0.2"
+      }
+    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -2158,9 +2173,19 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
       "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -2269,6 +2294,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -2445,7 +2475,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -2679,7 +2708,6 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2747,6 +2775,17 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/command-line-args": {
       "version": "5.2.1",
@@ -2861,6 +2900,71 @@
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="
+    },
+    "node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+    },
+    "node_modules/data-urls": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -2876,6 +2980,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.0.2",
@@ -2916,6 +3025,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dequal": {
@@ -2989,6 +3106,26 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/domexception/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.787",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.787.tgz",
@@ -3012,6 +3149,17 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
       "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
       "dev": true
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -3078,6 +3226,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/eslint": {
@@ -3373,7 +3549,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -3435,7 +3610,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3594,7 +3768,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -3649,6 +3822,19 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "peer": true
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -3786,8 +3972,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -3823,11 +4008,47 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -3836,6 +4057,17 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -4001,7 +4233,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -4025,6 +4256,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -4313,6 +4549,32 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-environment-jsdom": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
+      "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/jsdom": "^20.0.0",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jsdom": "^20.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
@@ -4396,7 +4658,6 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
       "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
         "@jest/types": "^29.6.3",
@@ -4416,7 +4677,6 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
       "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-      "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -4585,7 +4845,6 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
       "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -4685,8 +4944,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -4697,6 +4955,81 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.1",
+        "acorn-globals": "^7.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.4.2",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.11.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/jsesc": {
@@ -5402,13 +5735,31 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
       "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
-      "dev": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -5508,6 +5859,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.10.tgz",
+      "integrity": "sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ=="
     },
     "node_modules/obsidian": {
       "version": "1.5.7-1",
@@ -5707,6 +6063,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parsimmon": {
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.18.1.tgz",
@@ -5761,14 +6128,12 @@
     "node_modules/picocolors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
-      "dev": true
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -5907,7 +6272,6 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -5921,7 +6285,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -5951,11 +6314,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5975,6 +6342,11 @@
           "url": "https://opencollective.com/fast-check"
         }
       ]
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -6113,8 +6485,7 @@
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/readable-stream": {
       "version": "4.5.2",
@@ -6196,6 +6567,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -6328,6 +6704,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "node_modules/sass": {
       "version": "1.77.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.2.tgz",
@@ -6343,6 +6724,17 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -6392,7 +6784,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6401,7 +6792,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6435,7 +6826,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-      "dev": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -6447,7 +6837,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6620,6 +7009,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+    },
     "node_modules/synckit": {
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
@@ -6719,12 +7113,25 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tr46": {
@@ -6886,7 +7293,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -7020,6 +7426,14 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
@@ -7064,6 +7478,15 @@
       "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
       "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
       "dev": true
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -7135,6 +7558,17 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -7149,6 +7583,25 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -7232,6 +7685,39 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test": "jest --testPathIgnorePatterns=\\.performance\\.test\\.ts$",
     "test:verbose": "jest --verbose --testPathIgnorePatterns=\\.performance\\.test\\.ts$",
     "test:watch": "jest --watch --testPathIgnorePatterns=\\.performance\\.test\\.ts$",
-    "test:all": "jest --verbose"
+    "test:all": "jest --verbose",
+    "test:coverage": "jest --config jest.config.coverage.js --coverage --testPathIgnorePatterns=\\.performance\\.test\\.ts$"
   },
   "keywords": [],
   "author": "",
@@ -48,6 +49,7 @@
   "dependencies": {
     "crypto-js": "^4.2.0",
     "eslint-plugin-prettier": "^5.1.3",
+    "jest-environment-jsdom": "^29.7.0",
     "js-yaml": "^4.1.0",
     "remark": "^15.0.1",
     "remark-parse": "^11.0.0",

--- a/src/interfaces/IFileMetadata.ts
+++ b/src/interfaces/IFileMetadata.ts
@@ -1,0 +1,6 @@
+import { CachedMetadata, TFile } from 'obsidian';
+
+export default interface IFileMetadata {
+    file: TFile;
+    metadata: CachedMetadata;
+}

--- a/src/interfaces/IMetadataCache.ts
+++ b/src/interfaces/IMetadataCache.ts
@@ -1,0 +1,44 @@
+import { TFile } from 'obsidian';
+import IFileMetadata from './IFileMetadata';
+import { IMetadataCacheEvents } from './IMetadataCacheEvents';
+import { IEvent } from 'src/libs/GenericEvents';
+
+export default interface IMetadataCache {
+    get cache(): IFileMetadata[];
+    isCacheReady(): boolean;
+    waitForCacheReady(): Promise<void>;
+    getEntry(file: TFile): IFileMetadata | undefined;
+    getEntryByPath(path: string): IFileMetadata | undefined;
+    getEntryByLink(link: string, path: string): IFileMetadata | undefined;
+    getBacklinks(file: TFile): TFile[];
+
+    on<K extends keyof IMetadataCacheEvents['events']>(
+        eventName: K,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        listener: (
+            file: IMetadataCacheEvents['events'][K]['data'],
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ) => IMetadataCacheEvents['events'][K] extends IEvent<
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            any,
+            infer TReturn
+        >
+            ? TReturn
+            : void,
+    ): void;
+
+    off<K extends keyof IMetadataCacheEvents['events']>(
+        eventName: K,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        listener: (
+            file: IMetadataCacheEvents['events'][K]['data'],
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ) => IMetadataCacheEvents['events'][K] extends IEvent<
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            any,
+            infer TReturn
+        >
+            ? TReturn
+            : void,
+    ): void;
+}

--- a/src/interfaces/IMetadataCacheEvents.ts
+++ b/src/interfaces/IMetadataCacheEvents.ts
@@ -1,0 +1,21 @@
+import { TFile } from 'obsidian';
+import { ICallback, IEvent } from 'src/libs/GenericEvents';
+
+export interface IMetadataCacheEvents extends ICallback {
+    events: {
+        'prj-task-management-changed-status-event': IEvent<
+            TFile,
+            undefined | void
+        >;
+        'prj-task-management-file-changed-event': IEvent<
+            TFile,
+            undefined | void
+        >;
+        'document-changed-metadata-event': IEvent<TFile, undefined | void>;
+        'changes-in-kanban-event': IEvent<TFile, undefined | void>;
+        'file-rename-event': IEvent<
+            { oldPath: string; newPath: string },
+            undefined | void
+        >;
+    };
+}

--- a/src/libs/Tags.ts
+++ b/src/libs/Tags.ts
@@ -1,20 +1,18 @@
-// Note: TagLib class
-
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import Tag from 'src/libs/Tags/Tag';
 import { TFile } from 'obsidian';
 import Global from 'src/classes/Global';
+import { TagTree } from './Tags/types/TagTree';
 
 /**
- * Represents a hierarchical tree structure for tags.
+ * Provides methods to work with tags.
  */
-export type TagTree = {
-    [tag: string]: TagTree;
-};
-
 export default class Tags {
     /**
      * Returns the tags from the file.
      * @param file The file to get the tags from.
      * @returns The tags from the file.
+     * @deprecated Use {@link Tags.loadTagsFromFile} instead.
      */
     static getTagsFromFile(file: TFile | undefined): string[] {
         const tags: string[] = [];
@@ -43,6 +41,7 @@ export default class Tags {
      * Checks if the tag is a valid tag array
      * @param tag The tag array to check
      * @returns Whether the tag is a valid tag array
+     * @deprecated Use the new `Tags` and `Tag` class instead.
      */
     static isValidTag(tag: Array<string>): boolean {
         return tag && tag.length > 0;
@@ -52,6 +51,7 @@ export default class Tags {
      * Returns the valid tags array from the given tag/s
      * @param tags The tag/s to return the valid tags array from
      * @returns The valid tags array
+     * @deprecated Use the new `Tags` and `Tag` class instead.
      */
     static getValidTags(
         tags: string | Array<string> | undefined,
@@ -73,6 +73,7 @@ export default class Tags {
      * @param tagLabel - The label for the tag.
      * @param tag - The tag value.
      * @returns The created HTML anchor element.
+     * @deprecated Use {@link Tag.getObsidianLink} instead.
      */
     static createObsidianTagLink(
         tagLabel: string,
@@ -93,10 +94,12 @@ export default class Tags {
      * @param tags The tags array to filter out the non specific tags from
      * @returns The tags array without the non specific tags
      * @example removeRedundantTags(["tag1", "tag2", "tag1/subtag1", "tag1/subtag2"]) => ["tag2", "tag1/subtag1", "tag1/subtag2"]
+     * @deprecated Use {@link Tags.specificTags} instead.
      */
     static filterOutNonSpecificTags(tags: Array<string>): Array<string> {
         let cleanedTags: Array<string> = [];
 
+        // eslint-disable-next-line deprecation/deprecation
         if (this.isValidTag(tags)) {
             cleanedTags = tags.filter(
                 (tag) =>
@@ -114,6 +117,7 @@ export default class Tags {
      * Checks if the given tag exists in the metadata cache
      * @param tag The tag to check
      * @returns Whether the tag exists in the metadata cache
+     * @deprecated Use {@link Tag.exists} instead.
      */
     static existTag(tag: string): boolean {
         const metadataCache = Global.getInstance().metadataCache;
@@ -141,6 +145,7 @@ export default class Tags {
      * Creates a tag tree from an array of tags.
      * @param tags - The array of tags.
      * @returns The tag tree.
+     * @deprecated Use {@link Tags.getTagTree} instead.
      */
     static createTagTree(tags: Array<string>): TagTree {
         const tagTree: TagTree = {};
@@ -164,6 +169,7 @@ export default class Tags {
      * Returns an array of tag elements extracted from the given tag string.
      * @param tag - The tag string to extract tag elements from.
      * @returns An array of tag elements.
+     * @deprecated Use {@link Tag.getElements} instead.
      */
     static getTagElements(tag: string) {
         if (!tag || typeof tag !== 'string') return [];

--- a/src/libs/Tags/Tag.ts
+++ b/src/libs/Tags/Tag.ts
@@ -1,0 +1,181 @@
+import IMetadataCache from 'src/interfaces/IMetadataCache';
+import { ITag } from './interfaces/ITag';
+
+/**
+ * Represents a tag.
+ * @remarks The class extends the String class and provides additional methods to work with tags.
+ */
+export default class Tag implements ITag {
+    private _tag: string;
+
+    /**
+     * Sets the tag.
+     * @param value The value of the tag.
+     * @remarks If the tag is prefixed with a hash symbol, the symbol is removed.
+     */
+    private set value(value: string) {
+        this._tag = value.startsWith('#') ? value.slice(1) : value;
+    }
+
+    /**
+     * Gets the tag.
+     */
+    public get value(): string {
+        return this._tag;
+    }
+
+    /**
+     * The metadata cache.
+     */
+    private _metadataCache: IMetadataCache;
+
+    /**
+     * Gets the tag with a hash symbol.
+     * @returns The tag prefixed with a hash symbol.
+     */
+    public get tagWithHash(): string {
+        return `#${this._tag}`;
+    }
+
+    /**
+     * Whether the tag exists in the cache.
+     */
+    private _exists: boolean | undefined = undefined;
+
+    /**
+     * Gets whether the tag exists in the cache.
+     * @returns Whether the tag exists in the cache.
+     * @remarks Lazy loading is used to check if the tag exists in the cache.
+     */
+    public get exists(): boolean {
+        if (this._exists === undefined) {
+            const existFile = this._metadataCache.cache.find((file) => {
+                const tags = file.metadata?.frontmatter?.tags;
+
+                if (typeof tags === 'string') {
+                    return tags === this.tagWithHash;
+                } else if (Array.isArray(tags)) {
+                    return tags.includes(this.tagWithHash);
+                }
+
+                return false;
+            });
+
+            this._exists = existFile ? true : false;
+        }
+
+        return this._exists;
+    }
+
+    /**
+     * Creates a new instance of the Tag class.
+     * @param value The value of the tag.
+     * @param metadataCache The metadata cache. If not provided, the global metadata cache is used.
+     */
+    constructor(value: string, metadataCache: IMetadataCache) {
+        this.value = value;
+
+        this._metadataCache = metadataCache;
+    }
+
+    /**
+     * Converts the value of the tag to uppercase.
+     * @returns The value of the tag as an uppercase string.
+     */
+    public toUpperCase(): string {
+        return this.value.toUpperCase();
+    }
+
+    /**
+     * Converts the value of the tag to lowercase.
+     * @returns The value of the tag as a lowercase string.
+     */
+    public toLowerCase(): string {
+        return this.value.toLowerCase();
+    }
+
+    /**
+     * Returns the character at the specified index.
+     * @param index The index of the character to return.
+     * @returns The character at the specified index.
+     */
+    public charAt(index: number): string {
+        return this.value.charAt(index);
+    }
+
+    /**
+     * Checks if the tag includes the specified substring.
+     * @param substring The substring to search for.
+     * @returns Whether the tag includes the specified substring.
+     */
+    public includes(substring: string): boolean {
+        return this.value.includes(substring);
+    }
+
+    /**
+     * Return an array of elements from the tag.
+     * @returns An array of elements from the tag.
+     * @remarks The elements are separated by a forward slash.
+     */
+    public getElements(): string[] {
+        return this.value.split('/');
+    }
+
+    /**
+     * Creates an Obsidian tag link element.
+     * @param tagLabel The label for the tag link; if not provided, the tag with a hash symbol is used.
+     * @returns An Obsidian tag link element as an anchor element.
+     */
+    public getObsidianLink(tagLabel?: string): HTMLAnchorElement {
+        const obsidianLink = document.createElement('a');
+        obsidianLink.href = this.tagWithHash;
+        obsidianLink.classList.add('tag');
+        obsidianLink.target = '_blank';
+        obsidianLink.rel = 'noopener';
+        obsidianLink.textContent = `${tagLabel ?? this.tagWithHash}`;
+
+        return obsidianLink;
+    }
+
+    /**
+     * Overrides the valueOf method to return the primitive string value.
+     * @returns The primitive string value of the tag.
+     */
+    public valueOf(): string {
+        return this.value;
+    }
+
+    /**
+     * Overrides the toString method to return the string representation of the tag.
+     * @returns The string representation of the tag.
+     */
+    public toString(): string {
+        return this.value;
+    }
+
+    /**
+     * Checks if another tag is equal to this one based on the tag string.
+     * @param other The other tag to compare.
+     * @returns Whether the tags are equal.
+     */
+    public equals(other: ITag): boolean {
+        return this.value === other.toString();
+    }
+
+    /**
+     * Returns whether the tag starts with the specified search string.
+     * @param searchString The string to search for.
+     * @param position The position to start the search.
+     */
+    startsWith(searchString: string, position?: number): boolean {
+        return this.value.startsWith(searchString, position);
+    }
+
+    /**
+     * Checks if the object is an instance of the ITag interface.
+     * @param obj The object to check.
+     */
+    public isInstanceOfTag(obj: unknown): obj is ITag {
+        return obj instanceof Tag;
+    }
+}

--- a/src/libs/Tags/TagFactory.ts
+++ b/src/libs/Tags/TagFactory.ts
@@ -1,0 +1,14 @@
+import IMetadataCache from 'src/interfaces/IMetadataCache';
+import { ITag } from './interfaces/ITag';
+import { ITagFactory } from './interfaces/ITagFactory';
+import Tag from './Tag';
+
+/**
+ * A tag factory for {@link Tag} which implements {@link ITag}.
+ */
+
+export class TagFactory implements ITagFactory {
+    create(value: string, metadataCache: IMetadataCache): ITag {
+        return new Tag(value, metadataCache);
+    }
+}

--- a/src/libs/Tags/Tags.ts
+++ b/src/libs/Tags/Tags.ts
@@ -1,0 +1,338 @@
+import { ILogger } from 'src/interfaces/ILogger';
+
+import { TFile } from 'obsidian';
+import IMetadataCache from 'src/interfaces/IMetadataCache';
+import { ITag } from './interfaces/ITag';
+import { ITagFactory } from './interfaces/ITagFactory';
+import { ITags } from './interfaces/ITags';
+import { TagTree } from './types/TagTree';
+
+/**
+ * Represents an array of tags.
+ * @remarks - The class provides methods to add, remove, and get tags.
+ * - The class also provides a method to convert all tags to a string.
+ * - The class also takes care of any conversions so that an array of tags is always made available.
+ */
+export class Tags implements ITags {
+    /**
+     * The tag factory for the `ITag` interface.
+     */
+    private _iTagFactory: ITagFactory;
+
+    /**
+     * The tag helper. Used to check if an object is an instance of the `ITag` interface.
+     * @remarks Lazy loaded.
+     */
+    private static _tagHelper: ITag | undefined = undefined;
+
+    /**
+     * Checks if the object is an instance of the ITag interface.
+     * @param obj The object to check.
+     */
+    private isInstanceOfTag(obj: unknown): obj is ITag {
+        if (!Tags._tagHelper) {
+            Tags._tagHelper = this.createTag('');
+        }
+
+        return Tags._tagHelper.isInstanceOfTag(obj);
+    }
+
+    /**
+     * The metadata cache.
+     */
+    private _metadataCache: IMetadataCache;
+
+    /**
+     * The logger to use for logging messages.
+     * If not provided, no messages will be logged.
+     */
+    private logger: ILogger | undefined = undefined;
+
+    /**
+     * The tags array.
+     */
+    private _tags: ITag[] = [];
+
+    /**
+     * Gets the tags.
+     */
+    get values(): ITag[] {
+        return this._tags;
+    }
+
+    /**
+     * Only the specific tags.
+     * @remarks - Is lazy loaded.
+     */
+    private _specificTags: ITag[] | undefined = undefined;
+
+    /**
+     * The specific tags.
+     * - The specific tags are the tags without any redundant tags:
+     * If the tags array contains `["tag1", "tag2", "tag1/subtag1", "tag1/subtag2"]`,
+     * the specific tags are `["tag2", "tag1/subtag1", "tag1/subtag2"]`.
+     */
+    public get specificTags(): ITag[] {
+        if (!this._specificTags) {
+            this._specificTags = [];
+
+            this._tags.forEach((tag) => {
+                if (
+                    !this._tags.some(
+                        (existingTag) =>
+                            existingTag !== tag &&
+                            existingTag.startsWith(tag + '/'),
+                    )
+                ) {
+                    this._specificTags?.push(tag);
+                }
+            });
+        }
+
+        return this._specificTags;
+    }
+
+    /**
+     * Invalidates the specific tags.
+     */
+    private invalidateSpecificTags(): void {
+        this._specificTags = undefined;
+    }
+
+    /**
+     * Creates a new instance of the TagsArray class.
+     * @param tags The tags to use for the creation. Can be a string, an array of strings, or undefined.
+     * @param metadataCache The metadata cache.
+     * @param tagFactory The tag factory for the `ITag` interface.
+     * @param logger The logger to use for logging messages.
+     */
+    constructor(
+        tags: ITags | string | string[] | undefined | null,
+        metadataCache: IMetadataCache,
+        tagFactory: ITagFactory,
+        logger?: ILogger,
+    ) {
+        this._metadataCache = metadataCache;
+        this._iTagFactory = tagFactory;
+        this.logger = logger;
+        this._tags = [];
+
+        this.add(tags);
+    }
+
+    /**
+     * Creates a tag from a tag value.
+     * @param tagValue The tag value.
+     * @returns The created tag.
+     */
+    private createTag(tagValue: string): ITag {
+        return this._iTagFactory.create(tagValue, this._metadataCache);
+    }
+
+    /**
+     * Adds a tag, multiple tags or nothing to the tags array.
+     * @param tag The tag or tags to add.
+     * @returns Whether the tags were added.
+     * @remarks When adding, new `ITag` objects are always created for each tag.
+     */
+    public add(
+        tag: ITags | ITag | string | string[] | undefined | null,
+    ): boolean {
+        return this.push(...this.normalizeToTags(tag));
+    }
+
+    /**
+     * Normalizes different input types to an array of ITag-Objects.
+     * @param tag The input tag(s) to normalize.
+     * @returns An array of ITag-Objects.
+     */
+    private normalizeToTags(
+        tag: ITags | ITag | string | string[] | undefined | null,
+    ): ITag[] {
+        if (this.isInstanceOfTags(tag)) {
+            return tag.toStringArray().map((t) => this.createTag(t));
+        } else if (this.isInstanceOfTag(tag)) {
+            return [this.createTag(tag.value)];
+        } else if (Array.isArray(tag)) {
+            return tag.map((t) => this.createTag(t));
+        } else if (typeof tag === 'string') {
+            return [this.createTag(tag)];
+        }
+
+        return [];
+    }
+
+    /**
+     * Adds one or more tags to the tags array if they don't exist.
+     * @param tags The tags to add.
+     * @returns Whether the tags were added.
+     */
+    public push(...tags: ITag[]): boolean {
+        let added = false;
+
+        tags.forEach((tag) => {
+            if (!this.includes(tag)) {
+                this._tags.push(tag);
+                added = true;
+            } else {
+                this.logger?.warn(`Tag '${tag.value}' already exists.`);
+            }
+        });
+
+        if (added) {
+            this.invalidateSpecificTags();
+        } else {
+            this.logger?.warn('No tags added.');
+        }
+
+        return added;
+    }
+
+    /**
+     * Removes a tag from the tags array.
+     * @param tag The tag to remove.
+     * @returns Whether the tag was removed.
+     * @remarks The search is not for the specific object, but for an equal (string comparison) tag.
+     */
+    public remove(tag: ITag): boolean {
+        const index = this.findIndex(tag);
+
+        if (index !== -1) {
+            this._tags.splice(index, 1);
+            this.invalidateSpecificTags();
+
+            return true;
+        } else {
+            this.logger?.warn(`Tag '${tag}' not found.`);
+
+            return false;
+        }
+    }
+
+    /**
+     * Returns all tags.
+     * @returns All tags as an array of strings.
+     */
+    public toStringArray(): string[] {
+        return this._tags.map((tag) => tag.toString());
+    }
+
+    /**
+     * Returns all tags as a string.
+     * @returns All tags as a string separated by a comma.
+     */
+    public toString(): string {
+        return this._tags.join(', ');
+    }
+
+    /**
+     * Returns the number of tags.
+     */
+    public get length(): number {
+        return this._tags.length;
+    }
+
+    /**
+     * Checks if at least one tag in the tags array satisfies the provided testing function.
+     * @param predicate The function to test each tag.
+     * @returns `true` if the predicate function returns a truthy value for at least one tag; otherwise, `false`.
+     */
+    public some(predicate: (tag: ITag) => boolean): boolean {
+        return this._tags.some(predicate);
+    }
+
+    /**
+     * Checks if the tag exists in the tags array.
+     * @param tag The tag to check.
+     * @returns Whether the tag exists in the tags array.
+     */
+    public includes(tag: ITag): boolean {
+        return this._tags.some((existingTag) => existingTag.equals(tag));
+    }
+
+    /**
+     * Finds the index of the tag in the tags array.
+     * @param tag The tag to find.
+     * @returns The index of the tag in the tags array. If the tag is not found, -1 is returned.
+     */
+    public findIndex(tag: ITag): number {
+        return this._tags.findIndex((existingTag) => existingTag.equals(tag));
+    }
+
+    /**
+     * Returns an iterator for the TagsArray class.
+     * @returns An iterator object that iterates over the tags in the array.
+     */
+    public [Symbol.iterator](): Iterator<ITag> {
+        let index = 0;
+
+        return {
+            next: (): IteratorResult<ITag> => {
+                if (index < this._tags.length) {
+                    return {
+                        value: this._tags[index++],
+                        done: false,
+                    };
+                } else {
+                    return { done: true, value: undefined };
+                }
+            },
+        };
+    }
+
+    /**
+     * Creates a tag tree from an array of tags.
+     * @returns The tag tree.
+     */
+    public getTagTree(): TagTree {
+        const tagTree: TagTree = {};
+
+        this._tags.forEach((tag) => {
+            let currentTree = tagTree;
+
+            tag.getElements().forEach((element) => {
+                if (!currentTree[element]) {
+                    currentTree[element] = {};
+                }
+
+                currentTree = currentTree[element];
+            });
+        });
+
+        return tagTree;
+    }
+
+    /**
+     * Loads tags from a file.
+     * @param file The file to load the tags from.
+     * @remarks Any existing tags in the class are deleted in the process.
+     * @returns Whether the tags were loaded.
+     */
+    public loadTagsFromFile(file: TFile | undefined): boolean {
+        this._tags = [];
+
+        if (file) {
+            const cache = this._metadataCache.getEntry(file);
+
+            if (cache && cache.metadata && cache.metadata.frontmatter) {
+                return this.add(cache.metadata.frontmatter.tags);
+            } else {
+                this.logger?.warn('No metadata found in the file.');
+
+                return false;
+            }
+        } else {
+            this.logger?.warn('No file provided.');
+
+            return false;
+        }
+    }
+
+    /**
+     * Checks if the object is an instance of the ITags interface.
+     * @param obj The object to check.
+     */
+    public isInstanceOfTags(obj: unknown): obj is ITags {
+        return obj instanceof Tags;
+    }
+}

--- a/src/libs/Tags/__tests__/Tag.test.ts
+++ b/src/libs/Tags/__tests__/Tag.test.ts
@@ -1,0 +1,185 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import IMetadataCache from 'src/interfaces/IMetadataCache';
+import Tag from '../Tag';
+
+describe('Tag', () => {
+    let metadataCacheMock: IMetadataCache;
+
+    beforeEach(() => {
+        metadataCacheMock = {
+            cache: [
+                {
+                    metadata: {
+                        frontmatter: {
+                            tags: ['#exampleTag'],
+                        },
+                    },
+                },
+            ],
+        } as unknown as IMetadataCache;
+    });
+
+    // Constructor Tests
+    test('should initialize with a string value without hash', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        expect(tag.toString()).toBe('exampleTag');
+    });
+
+    test('should initialize with a string value with hash', () => {
+        const tag = new Tag('#exampleTag', metadataCacheMock);
+        expect(tag.toString()).toBe('exampleTag');
+    });
+
+    // Method Tests
+    test('should return the string value with toString', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        expect(tag.toString()).toBe('exampleTag');
+    });
+
+    test('should return the primitive string value with valueOf', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        expect(tag.valueOf()).toBe('exampleTag');
+    });
+
+    test('should return the string value in uppercase with toUpperCase', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        expect(tag.toUpperCase()).toBe('EXAMPLETAG');
+    });
+
+    test('should return the string value in lowercase with toLowerCase', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        expect(tag.toLowerCase()).toBe('exampletag');
+    });
+
+    test('should return the character at a specific position with charAt', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        expect(tag.charAt(0)).toBe('e');
+    });
+
+    test('should check if the tag includes a specific substring with includes', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        expect(tag.includes('ample')).toBe(true);
+        expect(tag.includes('notInTag')).toBe(false);
+    });
+
+    // Comparison Tests
+    test('should compare the Tag object with a string', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        expect(tag.toString() == 'exampleTag').toBe(true);
+    });
+
+    test('should compare the Tag object with an object using ==', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        const equalTagString = new Tag('exampleTag', metadataCacheMock);
+        expect(tag.equals(equalTagString)).toBe(true);
+    });
+
+    test('should use tag object in template literals correctly', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        expect(`This is a tag: ${tag}`).toBe('This is a tag: exampleTag');
+    });
+
+    test('should treat Tag instances as strings in concatenation', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        const result = tag + ' is cool';
+        expect(result).toBe('exampleTag is cool');
+    });
+
+    // Test `exists` property
+    test('should return true if tag exists in metadata cache', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        expect(tag.exists).toBe(true);
+    });
+
+    test('should return false if tag does not exist in metadata cache', () => {
+        const metadataCacheMockEmpty: IMetadataCache = {
+            cache: [],
+        } as unknown as IMetadataCache;
+        const tag = new Tag('exampleTag', metadataCacheMockEmpty);
+        expect(tag.exists).toBe(false);
+    });
+
+    test('should cache the existence check result', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        // Initial call should set the _exists value
+        expect(tag.exists).toBe(true);
+
+        // Manually set the _exists property to undefined to simulate a cache reset
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (tag as any)._exists = undefined;
+
+        // Modify the cache to check if the cached value is used
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (metadataCacheMock as any).cache = [];
+        expect(tag.exists).toBe(false);
+    });
+
+    // Test `tagWithHash` property
+    test('should return tag with hash', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        const tagWithHash = tag['tagWithHash'];
+        expect(tagWithHash).toBe('#exampleTag');
+    });
+
+    // Test `getObsidianLink` method
+    test('should return correct obsidian link', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        const obsidianLink = tag.getObsidianLink();
+
+        expect(obsidianLink.href.replace('http://localhost/', '')).toBe(
+            '#exampleTag',
+        );
+        expect(obsidianLink.textContent).toBe('#exampleTag');
+    });
+
+    test('should return correct obsidian link with custom label', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        const obsidianLink = tag.getObsidianLink('Custom Label');
+
+        expect(obsidianLink.href.replace('http://localhost/', '')).toBe(
+            '#exampleTag',
+        );
+        expect(obsidianLink.textContent).toBe('Custom Label');
+    });
+
+    // Test `startsWith` method
+    test('should return true if tag starts with a specific substring', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        expect(tag.startsWith('example')).toBe(true);
+    });
+
+    test('should return false if tag does not start with a specific substring', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        expect(tag.startsWith('notInTag')).toBe(false);
+    });
+
+    test('should return true if tag starts with a specific substring at a specific position', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        expect(tag.startsWith('ample', 2)).toBe(true);
+    });
+
+    test('should return false if tag does not start with a specific substring at a specific position', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        expect(tag.startsWith('ample', 3)).toBe(false);
+    });
+
+    // Test `getElements` method
+    test('should return an array of elements from the tag', () => {
+        const tag = new Tag('exampleTag/subtag', metadataCacheMock);
+        expect(tag.getElements()).toEqual(['exampleTag', 'subtag']);
+    });
+
+    // Test `isInstanceOfTag` method
+    test('should return true if object is instance of Tag', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        expect(tag.isInstanceOfTag(tag)).toBe(true);
+    });
+
+    test('should return false if object is not instance of Tag', () => {
+        const tag = new Tag('exampleTag', metadataCacheMock);
+        expect(tag.isInstanceOfTag({})).toBe(false);
+    });
+});

--- a/src/libs/Tags/__tests__/Tags.test.ts
+++ b/src/libs/Tags/__tests__/Tags.test.ts
@@ -1,0 +1,340 @@
+import { ILogger } from 'src/interfaces/ILogger';
+import IMetadataCache from 'src/interfaces/IMetadataCache';
+
+import { Tags } from '../Tags';
+import { ITagFactory } from '../interfaces/ITagFactory';
+import { ITag } from '../interfaces/ITag';
+import { TFile } from 'obsidian';
+
+describe('Tags', () => {
+    let mockLogger: ILogger;
+    let mockMetadataCache: IMetadataCache;
+    let mockTagFactory: ITagFactory;
+
+    beforeEach(() => {
+        mockLogger = {
+            warn: jest.fn(),
+            info: jest.fn(),
+            error: jest.fn(),
+            trace: jest.fn(),
+            debug: jest.fn(),
+        };
+
+        mockMetadataCache = {
+            getEntry: jest.fn(),
+        } as unknown as IMetadataCache;
+
+        mockTagFactory = {
+            create: jest.fn((tag: string, metadataCache: IMetadataCache) => ({
+                value: tag,
+                toString: () => tag,
+                getElements: () => tag.split('/'),
+                equals: (other: ITag) => other.toString() === tag,
+                isInstanceOfTag: (obj: unknown) => obj instanceof Tags,
+                startsWith: (str: string) => tag.startsWith(str),
+            })),
+        } as unknown as ITagFactory;
+    });
+
+    // Constructor Tests
+    test('should initialize with no tags and no logger', () => {
+        const tagsArray = new Tags(
+            undefined,
+            mockMetadataCache,
+            mockTagFactory,
+        );
+        expect(tagsArray.toStringArray()).toEqual([]);
+        expect(tagsArray.length).toBe(0);
+    });
+
+    test('should initialize with a single tag', () => {
+        const tagsArray = new Tags('tag1', mockMetadataCache, mockTagFactory);
+        expect(tagsArray.toStringArray()).toEqual(['tag1']);
+        expect(tagsArray.length).toBe(1);
+    });
+
+    test('should initialize with an array of tags', () => {
+        const tagsArray = new Tags(
+            ['tag1', 'tag2'],
+            mockMetadataCache,
+            mockTagFactory,
+        );
+        expect(tagsArray.toStringArray()).toEqual(['tag1', 'tag2']);
+        expect(tagsArray.length).toBe(2);
+    });
+
+    test('should initialize with undefined tags', () => {
+        const tagsArray = new Tags(
+            undefined,
+            mockMetadataCache,
+            mockTagFactory,
+            mockLogger,
+        );
+        expect(tagsArray.toStringArray()).toEqual([]);
+        expect(tagsArray.length).toBe(0);
+    });
+
+    // Method Tests
+    test('should add a single tag that does not exist', () => {
+        const tagsArray = new Tags(
+            [],
+            mockMetadataCache,
+            mockTagFactory,
+            mockLogger,
+        );
+        tagsArray.add('tag1');
+        expect(tagsArray.toStringArray()).toEqual(['tag1']);
+        expect(tagsArray.length).toBe(1);
+    });
+
+    test('should not add a single tag that already exists', () => {
+        const tagsArray = new Tags(
+            ['tag1'],
+            mockMetadataCache,
+            mockTagFactory,
+            mockLogger,
+        );
+        tagsArray.add('tag1');
+        expect(tagsArray.toStringArray()).toEqual(['tag1']);
+        expect(tagsArray.length).toBe(1);
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+            "Tag 'tag1' already exists.",
+        );
+    });
+
+    test('should add multiple tags', () => {
+        const tagsArray = new Tags(
+            [],
+            mockMetadataCache,
+            mockTagFactory,
+            mockLogger,
+        );
+        tagsArray.add(['tag1', 'tag2']);
+        expect(tagsArray.toStringArray()).toEqual(['tag1', 'tag2']);
+        expect(tagsArray.length).toBe(2);
+    });
+
+    test('should not add existing tags when adding multiple tags', () => {
+        const tagsArray = new Tags(
+            ['tag1'],
+            mockMetadataCache,
+            mockTagFactory,
+            mockLogger,
+        );
+        tagsArray.add(['tag1', 'tag2']);
+        expect(tagsArray.toStringArray()).toEqual(['tag1', 'tag2']);
+        expect(tagsArray.length).toBe(2);
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+            "Tag 'tag1' already exists.",
+        );
+    });
+
+    test('should log a warning when adding undefined tags', () => {
+        const tagsArray = new Tags(
+            [],
+            mockMetadataCache,
+            mockTagFactory,
+            mockLogger,
+        );
+        tagsArray.add(undefined);
+        expect(mockLogger.warn).toHaveBeenCalledWith('No tags added.');
+    });
+
+    test('should remove an existing tag', () => {
+        const tagsArray = new Tags(
+            ['tag1'],
+            mockMetadataCache,
+            mockTagFactory,
+            mockLogger,
+        );
+        tagsArray.remove(tagsArray.values[0]);
+        expect(tagsArray.toStringArray()).toEqual([]);
+        expect(tagsArray.length).toBe(0);
+    });
+
+    test('should log a warning when removing a non-existing tag', () => {
+        const tagsArray = new Tags(
+            ['tag1'],
+            mockMetadataCache,
+            mockTagFactory,
+            mockLogger,
+        );
+        const nonExistingTag = mockTagFactory.create('tag2', mockMetadataCache);
+        tagsArray.remove(nonExistingTag);
+        expect(tagsArray.toStringArray()).toEqual(['tag1']);
+        expect(tagsArray.length).toBe(1);
+        expect(mockLogger.warn).toHaveBeenCalledWith("Tag 'tag2' not found.");
+    });
+
+    test('should return all tags', () => {
+        const tagsArray = new Tags(
+            ['tag1', 'tag2'],
+            mockMetadataCache,
+            mockTagFactory,
+        );
+        expect(tagsArray.toStringArray()).toEqual(['tag1', 'tag2']);
+    });
+
+    test('should return all tags as a comma-separated string', () => {
+        const tagsArray = new Tags(
+            ['tag1', 'tag2'],
+            mockMetadataCache,
+            mockTagFactory,
+        );
+        expect(tagsArray.toString()).toBe('tag1, tag2');
+    });
+
+    test('should return the correct number of tags', () => {
+        const tagsArray = new Tags(
+            ['tag1', 'tag2'],
+            mockMetadataCache,
+            mockTagFactory,
+        );
+        expect(tagsArray.length).toBe(2);
+    });
+
+    test('should iterate over all tags', () => {
+        const tagsArray = new Tags(
+            ['tag1', 'tag2'],
+            mockMetadataCache,
+            mockTagFactory,
+        );
+        const tags: string[] = [];
+
+        for (const tag of tagsArray) {
+            tags.push(tag.toString());
+        }
+        expect(tags).toEqual(['tag1', 'tag2']);
+    });
+
+    // Additional Tests
+    test('should not add duplicate tags when initialized with an array containing duplicates', () => {
+        const tagsArray = new Tags(
+            ['tag1', 'tag1', 'tag2'],
+            mockMetadataCache,
+            mockTagFactory,
+            mockLogger,
+        );
+        expect(tagsArray.toStringArray()).toEqual(['tag1', 'tag2']);
+        expect(tagsArray.length).toBe(2);
+    });
+
+    test('should handle removing a tag from an empty array gracefully', () => {
+        const tagsArray = new Tags(
+            [],
+            mockMetadataCache,
+            mockTagFactory,
+            mockLogger,
+        );
+        const tagToRemove = mockTagFactory.create('tag1', mockMetadataCache);
+        tagsArray.remove(tagToRemove);
+        expect(tagsArray.toStringArray()).toEqual([]);
+        expect(tagsArray.length).toBe(0);
+        expect(mockLogger.warn).toHaveBeenCalledWith("Tag 'tag1' not found.");
+    });
+
+    test('should not log when adding a tag without a logger', () => {
+        const tagsArray = new Tags(['tag1'], mockMetadataCache, mockTagFactory);
+        tagsArray.add('tag1');
+        expect(tagsArray.toStringArray()).toEqual(['tag1']);
+        expect(tagsArray.length).toBe(1);
+        // Since no logger is provided, there should be no logs
+    });
+
+    test('should not log when removing a non-existing tag without a logger', () => {
+        const tagsArray = new Tags(['tag1'], mockMetadataCache, mockTagFactory);
+        const nonExistingTag = mockTagFactory.create('tag2', mockMetadataCache);
+        tagsArray.remove(nonExistingTag);
+        expect(tagsArray.toStringArray()).toEqual(['tag1']);
+        expect(tagsArray.length).toBe(1);
+        // Since no logger is provided, there should be no logs
+    });
+
+    // Tests for specificTags property
+    test('should return specific tags', () => {
+        const tagsArray = new Tags(
+            ['tag1', 'tag1/subtag1', 'tag2'],
+            mockMetadataCache,
+            mockTagFactory,
+        );
+
+        expect(tagsArray.specificTags.map((tag) => tag.toString())).toEqual([
+            'tag1/subtag1',
+            'tag2',
+        ]);
+    });
+
+    // Tests for getTagTree method
+    test('should return tag tree', () => {
+        const tagsArray = new Tags(
+            ['tag1', 'tag1/subtag1', 'tag2'],
+            mockMetadataCache,
+            mockTagFactory,
+        );
+
+        const expectedTree = {
+            tag1: {
+                subtag1: {},
+            },
+            tag2: {},
+        };
+        expect(tagsArray.getTagTree()).toEqual(expectedTree);
+    });
+
+    // Tests for loadTagsFromFile method
+    test('should load tags from file', () => {
+        const mockFile = { path: 'test.md' } as TFile;
+
+        mockMetadataCache.getEntry = jest.fn().mockReturnValue({
+            metadata: {
+                frontmatter: {
+                    tags: ['tag1', 'tag2'],
+                },
+            },
+        });
+
+        const tagsArray = new Tags(
+            [],
+            mockMetadataCache,
+            mockTagFactory,
+            mockLogger,
+        );
+        const result = tagsArray.loadTagsFromFile(mockFile);
+        expect(result).toBe(true);
+        expect(tagsArray.toStringArray()).toEqual(['tag1', 'tag2']);
+    });
+
+    test('should log warning if no metadata in file', () => {
+        const mockFile = { path: 'test.md' } as TFile;
+        mockMetadataCache.getEntry = jest.fn().mockReturnValue(null);
+
+        const tagsArray = new Tags(
+            [],
+            mockMetadataCache,
+            mockTagFactory,
+            mockLogger,
+        );
+        const result = tagsArray.loadTagsFromFile(mockFile);
+        expect(result).toBe(false);
+        expect(tagsArray.toStringArray()).toEqual([]);
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+            'No metadata found in the file.',
+        );
+    });
+
+    test('should log warning if no file provided', () => {
+        const tagsArray = new Tags(
+            [],
+            mockMetadataCache,
+            mockTagFactory,
+            mockLogger,
+        );
+        const result = tagsArray.loadTagsFromFile(undefined);
+        expect(result).toBe(false);
+        expect(tagsArray.toStringArray()).toEqual([]);
+        expect(mockLogger.warn).toHaveBeenCalledWith('No file provided.');
+    });
+});

--- a/src/libs/Tags/interfaces/ITag.ts
+++ b/src/libs/Tags/interfaces/ITag.ts
@@ -1,0 +1,95 @@
+/* eslint-disable @typescript-eslint/ban-types */
+
+/**
+ * Represents a tag.
+ */
+export interface ITag {
+    /**
+     * Gets whether the tag exists in the cache.
+     * @returns Whether the tag exists in the cache.
+     */
+    readonly exists: boolean;
+
+    /**
+     * Gets the tag.
+     */
+    get value(): string;
+
+    /**
+     * Gets the tag with a hash symbol.
+     * @returns The tag with a hash symbol.
+     * @remarks The tag is prefixed with a hash symbol if it doesn't already have one.
+     */
+    get tagWithHash(): string;
+
+    /**
+     * Converts the value of the tag to uppercase.
+     * @returns The value of the tag as an uppercase string.
+     */
+    toUpperCase(): string;
+
+    /**
+     * Converts the value of the tag to lowercase.
+     * @returns The value of the tag as a lowercase string.
+     */
+    toLowerCase(): string;
+
+    /**
+     * Returns the character at the specified index.
+     * @param index The index of the character to return.
+     * @returns The character at the specified index.
+     */
+    charAt(index: number): string;
+
+    /**
+     * Checks if the tag includes the specified substring.
+     * @param substring The substring to search for.
+     * @returns Whether the tag includes the specified substring.
+     */
+    includes(substring: string): boolean;
+
+    /**
+     * Return an array of elements from the tag.
+     * @returns An array of elements from the tag.
+     */
+    getElements(): string[];
+
+    /**
+     * Creates an Obsidian tag link element.
+     * @param tagLabel The label for the tag link; if not provided, the tag with a hash symbol is used.
+     * @returns An Obsidian tag link element as an anchor element.
+     */
+    getObsidianLink(tagLabel?: string): HTMLAnchorElement;
+
+    /**
+     * Overrides the valueOf method to return the primitive string value.
+     * @returns The primitive string value of the tag.
+     */
+    valueOf(): string;
+
+    /**
+     * Overrides the toString method to return the string representation of the tag.
+     * @returns The string representation of the tag.
+     */
+    toString(): string;
+
+    /**
+     * Checks if another tag is equal to this one based on the tag string.
+     * @param other The other tag to compare.
+     * @returns Whether the tags are equal.
+     */
+    equals(other: ITag): boolean;
+
+    /**
+     * Returns whether the tag starts with the specified search string.
+     * @param searchString The string to search for.
+     * @param position The position to start the search.
+     */
+    startsWith(searchString: string, position?: number): boolean;
+
+    /**
+     * Checks if the object is an instance of the ITag interface.
+     * @param obj The object to check.
+     */
+    isInstanceOfTag(obj: unknown): obj is ITag;
+}

--- a/src/libs/Tags/interfaces/ITagFactory.ts
+++ b/src/libs/Tags/interfaces/ITagFactory.ts
@@ -1,0 +1,15 @@
+import IMetadataCache from 'src/interfaces/IMetadataCache';
+import { ITag } from './ITag';
+
+/**
+ * Represents a tag factory.
+ */
+
+export interface ITagFactory {
+    /**
+     * Creates a new tag.
+     * @param tag The tag to create.
+     * @returns The created tag.
+     */
+    create(tag: string, metadataCache: IMetadataCache): ITag;
+}

--- a/src/libs/Tags/interfaces/ITags.ts
+++ b/src/libs/Tags/interfaces/ITags.ts
@@ -1,0 +1,105 @@
+import { TFile } from 'obsidian';
+import { ITag } from './ITag';
+import { TagTree } from '../types/TagTree';
+
+export interface ITags {
+    /**
+     * Gets the tags.
+     */
+    get values(): ITag[];
+
+    /**
+     * The specific tags.
+     * - The specific tags are the tags without any redundant tags:
+     * If the tags array contains `["tag1", "tag2", "tag1/subtag1", "tag1/subtag2"]`,
+     * the specific tags are `["tag2", "tag1/subtag1", "tag1/subtag2"]`.
+     */
+    get specificTags(): ITag[];
+
+    /**
+     * Adds a tag, multiple tags or nothing to the tags array.
+     * @param tag The tag or tags to add.
+     * @returns Whether the tags were added.
+     * @remarks When adding, new `ITag` objects are always created for each tag.
+     */
+    add(tag: ITags | ITag | string | string[] | undefined | null): boolean;
+
+    /**
+     * Adds one or more tags to the tags array if they don't exist.
+     * @param tags The tags to add.
+     * @returns Whether the tags were added.
+     */
+    push(...tags: ITag[]): boolean;
+
+    /**
+     * Removes a tag from the tags array.
+     * @param tag The tag to remove.
+     * @returns Whether the tag was removed.
+     * @remarks The search is not for the specific object, but for an equal (string comparison) tag.
+     */
+    remove(tag: ITag): boolean;
+
+    /**
+     * Returns all tags.
+     * @returns All tags as an array of strings.
+     */
+    toStringArray(): string[];
+
+    /**
+     * Returns all tags as a string.
+     * @returns All tags as a string separated by a comma.
+     */
+    toString(): string;
+
+    /**
+     * Returns the number of tags.
+     */
+    get length(): number;
+
+    /**
+     * Checks if at least one tag in the tags array satisfies the provided testing function.
+     * @param predicate The function to test each tag.
+     * @returns `true` if the predicate function returns a truthy value for at least one tag; otherwise, `false`.
+     */
+    some(predicate: (tag: ITag) => boolean): boolean;
+
+    /**
+     * Checks if the tag includes the specified tag.
+     * @param tag The tag to search for.
+     * @returns Whether the tag includes the specified tag.
+     */
+    includes(tag: ITag): boolean;
+
+    /**
+     * Finds the index of the tag in the tags array.
+     * @param tag The tag to find.
+     * @returns The index of the tag in the tags array. If the tag is not found, -1 is returned.
+     */
+    findIndex(tag: ITag): number;
+
+    /**
+     * Returns an iterator for the TagsArray class.
+     * @returns An iterator object that iterates over the tags in the array.
+     */
+    [Symbol.iterator](): Iterator<ITag>;
+
+    /**
+     * Creates a tag tree from an array of tags.
+     * @returns The tag tree.
+     */
+    getTagTree(): TagTree;
+
+    /**
+     * Loads tags from a file.
+     * @param file The file to load the tags from.
+     * @remarks Any existing tags in the class are deleted in the process.
+     * @returns Whether the tags were loaded.
+     */
+    loadTagsFromFile(file: TFile | undefined): boolean;
+
+    /**
+     * Checks if the object is an instance of the ITags interface.
+     * @param obj The object to check.
+     */
+    isInstanceOfTags(obj: unknown): obj is ITags;
+}

--- a/src/libs/Tags/types/TagTree.ts
+++ b/src/libs/Tags/types/TagTree.ts
@@ -1,0 +1,7 @@
+/**
+ * Represents a hierarchical tree structure for tags.
+ * @example { "tag1": { "subtag1": {}, "subtag2": {} }, "tag2": {} }
+ */
+export type TagTree = {
+    [tag: string]: TagTree;
+};

--- a/src/libs/__tests__/GenericEvents.test.ts
+++ b/src/libs/__tests__/GenericEvents.test.ts
@@ -21,146 +21,174 @@ describe('GenericEvents', () => {
     let logger: DummyLogger;
     let events: GenericEvents<MyEvents>;
 
-    beforeEach(() => {
-        logger = new DummyLogger();
-        events = new GenericEvents<MyEvents>(logger);
-    });
-
-    it('should register an event', () => {
-        const callback = jest.fn();
-        events.registerEvent('myEvent1', callback);
-        expect(logger.debug).toHaveBeenCalledWith('Event myEvent1 registered');
-    });
-
-    it('should deregister an event', () => {
-        const callback = jest.fn();
-        events.registerEvent('myEvent1', callback);
-        events.deregisterEvent('myEvent1', callback);
-
-        expect(logger.debug).toHaveBeenCalledWith(
-            'Event myEvent1 deregistered',
-        );
-    });
-
-    it('should log a warning if trying to deregister a non-existent event', () => {
-        const callback = jest.fn();
-        events.deregisterEvent('myEvent1', callback);
-
-        expect(logger.warn).toHaveBeenCalledWith(
-            'Event myEvent1 could not be deregistered',
-        );
-    });
-
-    it('should fire an event and execute the callback', (done) => {
-        const callback = jest.fn((data: string) => 100);
-
-        const resultCallback = jest.fn((result: number) => {
-            expect(result).toBe(100);
-            done();
+    const runTests = (loggerInstance?: ILogger) => {
+        beforeEach(() => {
+            events = new GenericEvents<MyEvents>(loggerInstance);
         });
 
-        events.registerEvent('myEvent1', callback);
-        events.fireEvent('myEvent1', 'Fire event 1', resultCallback);
-        expect(callback).toHaveBeenCalledWith('Fire event 1');
-        expect(logger.debug).toHaveBeenCalledWith('Event myEvent1 fired');
-    });
+        it('should register an event', () => {
+            const callback = jest.fn();
+            events.registerEvent('myEvent1', callback);
 
-    it('should handle errors in event handlers gracefully', async () => {
-        const error = new Error('Test error');
-
-        const callback = jest.fn(() => {
-            throw error;
+            if (loggerInstance) {
+                expect(loggerInstance.debug).toHaveBeenCalledWith(
+                    'Event myEvent1 registered',
+                );
+            }
         });
 
-        events.registerEvent('myEvent1', callback);
-        events.fireEvent('myEvent1', 'Fire event 1');
+        it('should deregister an event', () => {
+            const callback = jest.fn();
+            events.registerEvent('myEvent1', callback);
+            events.deregisterEvent('myEvent1', callback);
 
-        expect(callback).toHaveBeenCalledWith('Fire event 1');
-
-        expect(logger.error).toHaveBeenCalledWith(
-            `Error in event handler for ${callback.toString()}: ${error}`,
-        );
-    });
-
-    it('should not fire unregistered events', () => {
-        const callback = jest.fn();
-        events.fireEvent('myEvent1', 'Fire event 1', callback);
-        expect(callback).not.toHaveBeenCalled();
-    });
-
-    it('should only deregister the specified callback', () => {
-        const callback1 = jest.fn();
-        const callback2 = jest.fn();
-        events.registerEvent('myEvent1', callback1);
-        events.registerEvent('myEvent1', callback2);
-
-        events.deregisterEvent('myEvent1', callback1);
-
-        events.fireEvent('myEvent1', 'Fire event 1');
-        expect(callback1).not.toHaveBeenCalled();
-        expect(callback2).toHaveBeenCalled();
-    });
-
-    it('should handle multiple events correctly', (done) => {
-        const results: number[] = [];
-        let callbackCount = 0;
-
-        const callback1 = jest.fn((data: string) => {
-            results.push(1);
-
-            return 1;
+            if (loggerInstance) {
+                expect(loggerInstance.debug).toHaveBeenCalledWith(
+                    'Event myEvent1 deregistered',
+                );
+            }
         });
 
-        const callback2 = jest.fn((data: string) => {
-            results.push(2);
+        it('should log a warning if trying to deregister a non-existent event', () => {
+            const callback = jest.fn();
+            events.deregisterEvent('myEvent1', callback);
 
-            return 2;
+            if (loggerInstance) {
+                expect(loggerInstance.warn).toHaveBeenCalledWith(
+                    'Event myEvent1 could not be deregistered',
+                );
+            }
         });
 
-        const finalCallback = () => {
-            callbackCount++;
+        it('should fire an event and execute the callback', (done) => {
+            const callback = jest.fn((data: string) => 100);
 
-            if (callbackCount === 2) {
+            const resultCallback = jest.fn((result: number) => {
+                expect(result).toBe(100);
+                done();
+            });
+
+            events.registerEvent('myEvent1', callback);
+            events.fireEvent('myEvent1', 'Fire event 1', resultCallback);
+            expect(callback).toHaveBeenCalledWith('Fire event 1');
+
+            if (loggerInstance) {
+                expect(loggerInstance.debug).toHaveBeenCalledWith(
+                    'Event myEvent1 fired',
+                );
+            }
+        });
+
+        it('should handle errors in event handlers gracefully', async () => {
+            const error = new Error('Test error');
+
+            const callback = jest.fn(() => {
+                throw error;
+            });
+
+            events.registerEvent('myEvent1', callback);
+            events.fireEvent('myEvent1', 'Fire event 1');
+
+            expect(callback).toHaveBeenCalledWith('Fire event 1');
+
+            if (loggerInstance) {
+                expect(loggerInstance.error).toHaveBeenCalledWith(
+                    `Error in event handler for ${callback.toString()}: ${error}`,
+                );
+            }
+        });
+
+        it('should not fire unregistered events', () => {
+            const callback = jest.fn();
+            events.fireEvent('myEvent1', 'Fire event 1', callback);
+            expect(callback).not.toHaveBeenCalled();
+        });
+
+        it('should only deregister the specified callback', () => {
+            const callback1 = jest.fn();
+            const callback2 = jest.fn();
+            events.registerEvent('myEvent1', callback1);
+            events.registerEvent('myEvent1', callback2);
+
+            events.deregisterEvent('myEvent1', callback1);
+
+            events.fireEvent('myEvent1', 'Fire event 1');
+            expect(callback1).not.toHaveBeenCalled();
+            expect(callback2).toHaveBeenCalled();
+        });
+
+        it('should handle multiple events correctly', (done) => {
+            const results: number[] = [];
+            let callbackCount = 0;
+
+            const callback1 = jest.fn((data: string) => {
+                results.push(1);
+
+                return 1;
+            });
+
+            const callback2 = jest.fn((data: string) => {
+                results.push(2);
+
+                return 2;
+            });
+
+            const finalCallback = () => {
+                callbackCount++;
+
+                if (callbackCount === 2) {
+                    try {
+                        expect(results).toEqual([1, 2]);
+                        done();
+                    } catch (error) {
+                        done(error);
+                    }
+                }
+            };
+
+            events.registerEvent('myEvent1', callback1);
+            events.registerEvent('myEvent1', callback2);
+
+            events.fireEvent('myEvent1', 'Fire event 1', finalCallback);
+        });
+
+        it('should execute the callback after the event handler', (done) => {
+            const handler = jest.fn((data: string) => 100);
+
+            const callback = jest.fn((result: number) => {
                 try {
-                    expect(results).toEqual([1, 2]);
+                    expect(result).toBe(100);
                     done();
                 } catch (error) {
                     done(error);
                 }
-            }
-        };
+            });
 
-        events.registerEvent('myEvent1', callback1);
-        events.registerEvent('myEvent1', callback2);
+            events.registerEvent('myEvent1', handler);
+            events.fireEvent('myEvent1', 'Test data', callback);
 
-        events.fireEvent('myEvent1', 'Fire event 1', finalCallback);
+            // Wait for the event handler to execute
+            setTimeout(() => {
+                try {
+                    if (loggerInstance) {
+                        expect(loggerInstance.debug).toHaveBeenCalledWith(
+                            `Callback for ${handler.toString()} executed`,
+                        );
+                    }
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 0);
+        });
+    };
+
+    describe('with logger', () => {
+        logger = new DummyLogger();
+        runTests(logger);
     });
 
-    it('should execute the callback after the event handler', (done) => {
-        const handler = jest.fn((data: string) => 100);
-
-        const callback = jest.fn((result: number) => {
-            try {
-                expect(result).toBe(100);
-                done();
-            } catch (error) {
-                done(error);
-            }
-        });
-
-        events.registerEvent('myEvent1', handler);
-        events.fireEvent('myEvent1', 'Test data', callback);
-
-        // Wait for the event handler to execute
-        setTimeout(() => {
-            try {
-                expect(logger.debug).toHaveBeenCalledWith(
-                    `Callback for ${handler.toString()} executed`,
-                );
-                done();
-            } catch (error) {
-                done(error);
-            }
-        }, 0);
+    describe('without logger', () => {
+        runTests();
     });
 });


### PR DESCRIPTION
**Adoption of the desired changes from the branch `refactoring/add-tagsarray` PR #43**

- Added a new `jest.config.coverage.js` file to configure and enable coverage reporting in Jest. Updated `.gitignore` to ignore coverage output and added a `test:coverage` script in `package.json`.
- Created `IFileMetadata` and `IMetadataCache` interfaces for better encapsulation and use in the caching system.
- Introduced the `Tag`, `TagFactory`, and `Tags` classes with their associated interfaces for managing tag metadata. Added methods to work with tags and replaced deprecated methods.
- Updated the existing `MetadataCache` class to implement the new `IMetadataCache` interface, ensuring better event handling and metadata management.
- Created comprehensive tests for `Tag`, `Tags`, and `GenericEvents` classes to ensure functionality and error handling.
- Added dependencies for `jest-environment-jsdom` to support Jest testing environment.

These changes collectively improve tag management, ensure better event handling, and add comprehensive test coverage and insightful metrics for the project.