### PR TITLE
Add unit tests for SearchElement, SearchOperator, and SearchTerm

### DIFF
--- a/src/libs/Search/__tests__/SearchElement.test.ts
+++ b/src/libs/Search/__tests__/SearchElement.test.ts
@@ -1,0 +1,60 @@
+import SearchElement from '../SearchElement';
+
+// Concrete implementation for testing purposes
+class ConcreteSearchElement extends SearchElement {
+    constructor(value: string, negated = false) {
+        if (negated === undefined || negated === false) {
+            super(value);
+        } else {
+            super(value, negated);
+        }
+    }
+
+    get isOperator(): boolean {
+        // For testing purposes always returns false
+        return false;
+    }
+}
+
+// Jest tests
+describe('SearchElement', () => {
+    let searchElement: ConcreteSearchElement;
+
+    beforeEach(() => {
+        searchElement = new ConcreteSearchElement('testValue', true);
+    });
+
+    test('should initialize with correct values', () => {
+        expect(searchElement.value).toBe('testValue');
+        expect(searchElement.negated).toBe(true);
+    });
+
+    test('should set value correctly', () => {
+        searchElement.value = 'newValue';
+        expect(searchElement.value).toBe('newValue');
+    });
+
+    test('should set negated correctly', () => {
+        searchElement.negated = false;
+        expect(searchElement.negated).toBe(false);
+    });
+
+    test('isOperator should return correct value', () => {
+        expect(searchElement.isOperator).toBe(false);
+    });
+
+    test('should initialize with default negated value as false', () => {
+        const defaultNegatedElement = new ConcreteSearchElement(
+            'defaultTestValue',
+        );
+        expect(defaultNegatedElement.negated).toBe(false);
+    });
+
+    test('should initialize with negated value as true', () => {
+        const negatedElement = new ConcreteSearchElement(
+            'negatedTestValue',
+            true,
+        );
+        expect(negatedElement.negated).toBe(true);
+    });
+});

--- a/src/libs/Search/__tests__/SearchOperator.test.ts
+++ b/src/libs/Search/__tests__/SearchOperator.test.ts
@@ -1,0 +1,37 @@
+import SearchElement from '../SearchElement';
+import SearchOperator from '../SearchOperator';
+
+describe('SearchOperator', () => {
+    let searchOperator: SearchOperator;
+
+    beforeEach(() => {
+        searchOperator = new SearchOperator('&');
+    });
+
+    test('should initialize with correct operator value', () => {
+        expect(searchOperator.operator).toBe('&');
+    });
+
+    test('should set operator value correctly', () => {
+        searchOperator.operator = '|';
+        expect(searchOperator.operator).toBe('|');
+    });
+
+    test('isOperator should return true', () => {
+        expect(searchOperator.isOperator).toBe(true);
+    });
+
+    test('should initialize with operator type', () => {
+        const orOperator = new SearchOperator('|');
+        expect(orOperator.operator).toBe('|');
+    });
+
+    test('should inherit from SearchElement', () => {
+        expect(searchOperator).toBeInstanceOf(SearchElement);
+    });
+
+    test('should handle negated value correctly', () => {
+        searchOperator.negated = true;
+        expect(searchOperator.negated).toBe(true);
+    });
+});

--- a/src/libs/Search/__tests__/SearchQuery.test.ts
+++ b/src/libs/Search/__tests__/SearchQuery.test.ts
@@ -28,6 +28,30 @@ describe('SearchQuery', () => {
         );
     });
 
+    it('should match text correctly for terms with negated AND operator', () => {
+        const query = SearchParser.parse('term1 !& term2');
+
+        expect(query.matches('This is a text with term 2 but not term1')).toBe(
+            true,
+        );
+
+        expect(query.matches('This is a text with term1 and term2')).toBe(
+            false,
+        );
+    });
+
+    it('should match text correctly for terms with negated OR operator', () => {
+        const query = SearchParser.parse('term1 !| term2');
+
+        expect(query.matches('This is a text with term 2 but not term1')).toBe(
+            true,
+        );
+
+        expect(query.matches('This is a text with term 1 and term2')).toBe(
+            false,
+        );
+    });
+
     it('should match text correctly for quoted terms', () => {
         const query = SearchParser.parse('"term1 term2"');
         expect(query.matches('This is a text with term1 term2')).toBe(true);

--- a/src/libs/Search/__tests__/SearchTerm.test.ts
+++ b/src/libs/Search/__tests__/SearchTerm.test.ts
@@ -1,0 +1,37 @@
+import SearchElement from '../SearchElement';
+import SearchTerm from '../SearchTerm';
+
+describe('SearchTerm', () => {
+    let searchTerm: SearchTerm;
+
+    beforeEach(() => {
+        searchTerm = new SearchTerm('testTerm');
+    });
+
+    test('should initialize with correct term value', () => {
+        expect(searchTerm.term).toBe('testTerm');
+    });
+
+    test('should set term value correctly', () => {
+        searchTerm.term = 'newTerm';
+        expect(searchTerm.term).toBe('newTerm');
+    });
+
+    test('isOperator should return false', () => {
+        expect(searchTerm.isOperator).toBe(false);
+    });
+
+    test('should initialize with term value', () => {
+        const newSearchTerm = new SearchTerm('anotherTerm');
+        expect(newSearchTerm.term).toBe('anotherTerm');
+    });
+
+    test('should inherit from SearchElement', () => {
+        expect(searchTerm).toBeInstanceOf(SearchElement);
+    });
+
+    test('should handle negated value correctly', () => {
+        searchTerm.negated = true;
+        expect(searchTerm.negated).toBe(true);
+    });
+});


### PR DESCRIPTION
Implemented Jest test suites for `SearchElement`, `SearchOperator`, and `SearchTerm` to verify their correct initialization, attribute setting, and inheritance behavior. Added tests in `SearchQuery` to ensure correct matching of terms with negated AND and OR operators. This improves test coverage and reliability of Search functionality.

Result:
------------------------------------|---------|----------|---------|---------|-------------------
File                                | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
------------------------------------|---------|----------|---------|---------|-------------------
 libs/Search                        |     100 |      100 |     100 |     100 |
  SearchElement.ts                  |     100 |      100 |     100 |     100 |
  SearchOperator.ts                 |     100 |      100 |     100 |     100 |
  SearchOperatorTypes.ts            |     100 |      100 |     100 |     100 |
  SearchParser.ts                   |     100 |      100 |     100 |     100 |
  SearchQuery.ts                    |     100 |      100 |     100 |     100 |
  SearchTerm.ts                     |     100 |      100 |     100 |     100 |