### PR TITLE
Add Typedoc script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint": "eslint --ext .ts .",
     "lint:fix": "eslint --fix --ext .ts .",
     "format": "prettier --write .",
+    "docs": "typedoc",
     "version:show": "node -e \"console.log(require('./package.json').version)\"",
     "test": "jest",
     "test:file": "jest --watch --onlyChanged --coverage=true --verbose",


### PR DESCRIPTION
Enhanced developer tools by adding a "docs" script to generate documentation using Typedoc. This simplifies the process of creating and updating project documentation, improving maintainability and developer onboarding.