### PR TITLE
Refactor CopyMarkdownLink to improve lifecycle management

### DIFF
--- a/src/libs/ContextMenus/CopyMarkdownLink.ts
+++ b/src/libs/ContextMenus/CopyMarkdownLink.ts
@@ -1,4 +1,5 @@
 import { Menu, TAbstractFile, TFile } from 'obsidian';
+import { ImplementsStatic } from 'src/classes/decorators/ImplementsStatic';
 import { Singleton } from 'src/classes/decorators/Singleton';
 import { ContextMenu } from './ContextMenu';
 import { IContextMenu } from './interfaces/IContextMenu';
@@ -9,13 +10,13 @@ import ITranslationService from '../TranslationService/interfaces/ITranslationSe
 
 /**
  * Represents a context menu for copying markdown links.
+ * @see {@link Singleton}
+ * @see {@link Lifecycle}
  */
 @Lifecycle
+@ImplementsStatic<ILifecycleObject>()
 @Singleton
-export class CopyMarkdownLink
-    extends ContextMenu
-    implements IContextMenu, ILifecycleObject
-{
+export class CopyMarkdownLink extends ContextMenu implements IContextMenu {
     protected bindContextMenu = this.onContextMenu.bind(this);
     private _translationService: ITranslationService;
 
@@ -35,15 +36,17 @@ export class CopyMarkdownLink
     /**
      * This method is called when the application is unloaded.
      */
-    public onLoad(): void {
-        this.isInitialized();
+    public static onLoad(): void {
+        const instance = new CopyMarkdownLink();
+        instance.isInitialized();
     }
 
     /**
      * This method is called when the application is unloaded.
      */
-    public onUnload(): void {
-        this.deconstructor();
+    public static onUnload(): void {
+        const instance = new CopyMarkdownLink();
+        instance.deconstructor();
     }
 
     /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,6 @@ import API from './classes/API';
 import Global from './classes/Global';
 import Lng from './classes/Lng';
 import { Logging } from './classes/Logging';
-import { CopyMarkdownLink } from './libs/ContextMenus/CopyMarkdownLink';
 import GetMetadata from './libs/ContextMenus/GetMetadata';
 import { DIContainer } from './libs/DependencyInjection/DIContainer';
 import { IDIContainer } from './libs/DependencyInjection/interfaces/IDIContainer';
@@ -110,8 +109,6 @@ export default class Prj extends Plugin {
      * Register the Obsidian Commands an Events
      */
     private registerCommandsAndEvents(): void {
-        new CopyMarkdownLink();
-
         // Create New Metadata File Command
         CreateNewMetadataModal.registerCommand();
 
@@ -201,7 +198,6 @@ export default class Prj extends Plugin {
         new LifecycleManager().onUnload();
 
         GetMetadata.deconstructor();
-        new CopyMarkdownLink().deconstructor();
         Global.deconstructor();
     }
 


### PR DESCRIPTION
Refactored the CopyMarkdownLink context menu class to implement static lifecycle methods (onLoad and onUnload) instead of instance methods, ensuring proper initialization and unloading logic. Applied the @ImplementsStatic decorator for better type checking and supplemented the class with the ILifecycleObject interface. Updated main plugin class to reflect these changes by removing direct instantiation and clean-up calls. This enhances the code's maintainability and adherence to design patterns.