### PR TITLE
Refactoring/get-metadata-context-menu

### DIFF
--- a/src/libs/ContextMenus/CopyMarkdownLink.ts
+++ b/src/libs/ContextMenus/CopyMarkdownLink.ts
@@ -21,8 +21,8 @@ export class CopyMarkdownLink extends ContextMenu implements IContextMenu {
     private _translationService: ITranslationService;
 
     /**
-     * Creates an instance of CopyMarkdownLinkContextMenu.
-     * @param dependencies - The dependencies for the context menu.
+     * Creates an instance of CopyMarkdownLink.
+     * @param dependencies The dependencies for the context menu.
      */
     constructor(dependencies?: IDIContainer) {
         super(dependencies);

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,6 @@ import API from './classes/API';
 import Global from './classes/Global';
 import Lng from './classes/Lng';
 import { Logging } from './classes/Logging';
-import GetMetadata from './libs/ContextMenus/GetMetadata';
 import { DIContainer } from './libs/DependencyInjection/DIContainer';
 import { IDIContainer } from './libs/DependencyInjection/interfaces/IDIContainer';
 import Helper from './libs/Helper';
@@ -81,9 +80,6 @@ export default class Prj extends Plugin {
     async onLayoutReady(): Promise<void> {
         this._dependencies = DIContainer.getInstance();
         this.registerDependencies();
-
-        // Get Metadata File Context Menu & Command
-        GetMetadata.getInstance();
 
         // Copy Markdown Link Context Menu
         //CopyMarkdownLink.getInstance();
@@ -197,7 +193,6 @@ export default class Prj extends Plugin {
         console.log("Unloading plugin 'PRJ'");
         new LifecycleManager().onUnload();
 
-        GetMetadata.deconstructor();
         Global.deconstructor();
     }
 


### PR DESCRIPTION
- Revised the GetMetadata class to implement proper dependency injection (DI) using decorators like `@Singleton`, `@Lifecycle`, and `@ImplementsStatic`. This replaces the previous singleton pattern dependent on a global instance. Simplified the constructor and lifecycle management by refactoring event registration commands into dedicated onLoad and onUnload methods. Enhanced logging and translation retrieval by resolving dependencies directly, improving code readability and maintainability.

- Eliminated references to GetMetadata to clean up unused imports and enhance maintainability. The methods related to GetMetadata initialization and deconstruction were also removed, simplifying the plugin's load and unload processes. This change reduces overhead and potential confusion from deprecated code components.