### PR TITLE
Automate TypeDoc deployment with GitHub Actions

### DIFF
--- a/.github/workflows/Deploy-TypeDoc.yml
+++ b/.github/workflows/Deploy-TypeDoc.yml
@@ -1,0 +1,42 @@
+name: Deploy Documentation
+
+on:
+    push:
+        branches:
+            - main
+    workflow_dispatch: # Ermöglicht das manuelle Ausführen des Workflows
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '20.8.0'
+
+            - name: Install Dependencies
+              run: npm install
+
+            - name: Run TypeDoc
+              run: npx typedoc
+
+            - name: Deploy to GitHub Pages
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  git config --global user.name 'github-actions[bot]'
+                  git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+                  git clone --single-branch --branch gh-pages https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} gh-pages
+                  rm -rf gh-pages/*
+                  cp -r docs/* gh-pages/
+                  cd gh-pages
+                  git add .
+                  git commit -m 'Deploy documentation'
+                  git push origin gh-pages


### PR DESCRIPTION
Added a GitHub Actions workflow to automate the deployment of TypeDoc documentation. On every push to the main branch or manual trigger, the workflow checks out code, sets up Node.js, installs dependencies, runs TypeDoc, and deploys the generated documentation to the gh-pages branch. This streamlines the documentation update process and ensures consistency.