### PR TITLE
Add coverage folder in deploy script

### DIFF
--- a/.github/workflows/Deploy-TypeDoc.yml
+++ b/.github/workflows/Deploy-TypeDoc.yml
@@ -40,6 +40,7 @@ jobs:
                   git clone --single-branch --branch gh-pages https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} gh-pages
                   rm -rf gh-pages/*
                   cp -r docs/* gh-pages/
+                  mkdir -p gh-pages/coverage
                   cp -r coverage/* gh-pages/coverage/
                   cd gh-pages
                   git add .


### PR DESCRIPTION
Updated deploy script to create a 'coverage' directory in the 'gh-pages' branch, ensuring test coverage reports are included in the deployment alongside documentation. This helps in maintaining transparency about test coverage on the project documentation site.