### PR TITLE
Update test:coverage script to run commands concurrently

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:verbose": "jest --verbose",
     "test:watch": "jest --watch --onlyChanged --verbose",
     "test:performance": "jest --config jest.config.performance.js --runInBand --verbose",
-    "test:coverage": "jest --config jest.config.coverage.js --coverage && node fix-lcov-paths.js"
+    "test:coverage": "jest --config jest.config.coverage.js --coverage & node fix-lcov-paths.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Revised the 'test:coverage' script to use a single ampersand (&) for concurrent execution of Jest and the fix-lcov-paths.js script. This change reduces execution time by running both commands simultaneously, improving development efficiency.