### PR TITLE
Convert plain link to HTML anchor tag

### DIFF
--- a/Docs.md
+++ b/Docs.md
@@ -4,4 +4,4 @@
 
 # Test Abdeckung
 
-[Test Abdeckung..](./coverage/lcov-report/index.html)
+<a href="./coverage/lcov-report/index.html">Test Abdeckung..</a>


### PR DESCRIPTION
Updated the documentation to use an HTML anchor tag for the test coverage link. This change improves readability and ensures better compatibility with markdown renderers that might not process plain links correctly.