### PR TITLE
Deprecate methods and remove Docs.md file

### DIFF
--- a/Docs.md
+++ b/Docs.md
@@ -1,7 +1,0 @@
-![Time](https://waka.mpassarello.de/api/badge/MaxP/interval:any/project:prj?label=Project%20time)
-
-# Prj-Plugin
-
-# Test Abdeckung
-
-[Test Abdeckung..](https://pxammaxp.github.io/obsidian-prj/coverage/lcov-report/index.html)

--- a/src/models/DocumentModel.ts
+++ b/src/models/DocumentModel.ts
@@ -5,6 +5,7 @@ import { Path } from 'src/classes/Path';
 import { IDIContainer } from 'src/libs/DependencyInjection/interfaces/IDIContainer';
 import FileManager, { Filename } from 'src/libs/FileManager';
 import { HelperGeneral } from 'src/libs/Helper/General';
+import CreateNewMetadataModal from 'src/libs/Modals/CreateNewMetadataModal';
 import { Wikilink } from 'src/libs/Wikilink/Wikilink';
 import DocumentData from './Data/DocumentData';
 import { FileModel } from './FileModel';
@@ -213,13 +214,15 @@ export class DocumentModel
         return this.data.uid ?? '';
     }
 
+    //#region Static API
     /**
      * Static API for the DocumentModel class.
      */
-    //#region Static API
+
     /**
      * Returns all documents
      * @returns List of all documents
+     * @deprecated This method is deprecated and will be removed in a future release.
      */
     public static getAllDocuments(): DocumentModel[] {
         const metadataCache = Global.getInstance().metadataCache.cache;
@@ -290,6 +293,7 @@ export class DocumentModel
      * @returns List of PDFs without metadata files
      * @remarks - This function searches for all PDFs without a corresponding metadata file.
      * - The function uses the metadataCache and fileCache to find all PDFs without a metadata file.
+     * @see {@link CreateNewMetadataModal.constructForm}
      */
     public static getAllPDFsWithoutMetadata(): TFile[] {
         const metadataCache = Global.getInstance().metadataCache.cache;

--- a/src/models/NoteModel.ts
+++ b/src/models/NoteModel.ts
@@ -42,6 +42,7 @@ export class NoteModel
      * Get a wikilink for the note
      * @param text The text to display in the wikilink
      * @returns The wikilink. E.g. `[[FileName]]` or `[[FileName|Text]]`
+     * @deprecated This method is deprecated and will be removed in a future version.
      */
     public getWikilink(text: string | undefined): string {
         if (text) {
@@ -54,6 +55,7 @@ export class NoteModel
     /**
      * Returns the file contents of the document
      * @returns String containing the file contents
+     * @deprecated This method is deprecated and will be removed in a future version.
      */
     public async getFileContents(): Promise<string | undefined> {
         try {
@@ -66,6 +68,7 @@ export class NoteModel
     /**
      * Returns the tags of the document as an array of strings
      * @returns Array of strings containing the tags
+     * @deprecated This method is deprecated and will be removed in a future version.
      */
     public getTags(): string[] {
         const tags = this.data.tags;
@@ -80,10 +83,11 @@ export class NoteModel
         return formattedTags;
     }
 
+    //#region Static API
     /**
      * Static API for the NoteModel class.
      */
-    //#region Static API
+
     /**
      * Generates a filename based on the provided NoteModel.
      * @param model The NoteModel object used to generate the filename.

--- a/src/models/TaskModel.ts
+++ b/src/models/TaskModel.ts
@@ -38,8 +38,10 @@ export class TaskModel extends PrjTaskManagementModel<TaskData> {
 
     /**
      * The related tasks.
+     * @deprecated This method is deprecated and will be removed in a future version.
      */
     public get relatedTasks(): TaskModel[] {
+        // eslint-disable-next-line deprecation/deprecation
         this._relatedTasks = this._relatedTasks ?? this.getRelatedTasks();
 
         return this._relatedTasks;
@@ -60,6 +62,7 @@ export class TaskModel extends PrjTaskManagementModel<TaskData> {
      * Returns the related tasks.
      * @param status A delegate to filter the tasks by status.
      * @returns The related tasks.
+     * @deprecated This method is deprecated and will be removed in a future version.
      */
     private getRelatedTasks(
         status?: (status: Status | undefined) => boolean,


### PR DESCRIPTION
Deprecated multiple methods across DocumentModel, NoteModel, and TaskModel to signal future removal. Added references to CreateNewMetadataModal in DocumentModel. Deleted the obsolete Docs.md file.