### PR TITLE
Enable prefer-string-starts-ends-with rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -271,7 +271,8 @@
         "allowTypedFunctionExpressions": true,
         "allowHigherOrderFunctions": true
       }
-    ]
+    ],
+    "@typescript-eslint/prefer-string-starts-ends-with": "warn"
   },
   "overrides": [
     {


### PR DESCRIPTION
Added "@typescript-eslint/prefer-string-starts-ends-with" rule with a warning level to enforce the use of string startsWith and endsWith methods, improving code readability and consistency when checking string prefixes and suffixes.