### PR TITLE
Refactoring/lint-rules/prefer-optional-chain

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -273,7 +273,8 @@
       }
     ],
     "@typescript-eslint/prefer-string-starts-ends-with": "warn",
-    "@typescript-eslint/no-misused-promises": "warn"
+    "@typescript-eslint/no-misused-promises": "warn",
+    "@typescript-eslint/prefer-optional-chain": "warn"
   },
   "overrides": [
     {

--- a/src/classes/decorators/Helper.ts
+++ b/src/classes/decorators/Helper.ts
@@ -20,7 +20,7 @@ export function copyStaticProperties<SourceType>(
                         prop,
                     );
 
-                    if (descriptor && descriptor.configurable) {
+                    if (descriptor?.configurable) {
                         Object.defineProperty(target, prop, descriptor);
                     }
                 }

--- a/src/libs/FileManager.ts
+++ b/src/libs/FileManager.ts
@@ -26,7 +26,7 @@ export default class FileManager {
     ): Promise<boolean> {
         const logger = Logging.getLogger('FileManager/renameFile');
 
-        if (!file || !file.parent?.path || !filename) {
+        if (!file?.parent?.path || !filename) {
             filename ?? logger.error('No new filename provided');
             file ?? logger.error('No file provided');
             file.parent?.path ?? logger.error('No parent path provided');

--- a/src/libs/Table.ts
+++ b/src/libs/Table.ts
@@ -229,10 +229,7 @@ export default class Table {
             const tableCell = tableRow.insertCell();
             tableCell.classList.add(...this._defaultClasses.cell);
 
-            if (
-                this._headers[index] !== undefined &&
-                this._headers[index].columnClass
-            ) {
+            if (this._headers[index]?.columnClass) {
                 this._headers[index].columnClass?.forEach((classItem) => {
                     tableCell.classList.add(classItem);
                 });

--- a/src/libs/Tags/Tags.ts
+++ b/src/libs/Tags/Tags.ts
@@ -355,7 +355,7 @@ export class Tags extends BaseComplexDataType implements ITags {
         if (file) {
             const cache = this._IMetadataCache.getEntry(file);
 
-            if (cache && cache.metadata && cache.metadata.frontmatter) {
+            if (cache?.metadata?.frontmatter) {
                 return this.add(cache.metadata.frontmatter.tags);
             } else {
                 this._logger?.warn('No metadata found in the file.');

--- a/src/models/Data/PrjBaseData.ts
+++ b/src/models/Data/PrjBaseData.ts
@@ -44,7 +44,7 @@ export default abstract class PrjBaseData<T> {
         for (const config of this.fieldConfig) {
             const key = config.key as keyof T;
 
-            if (data && data[key] !== undefined) {
+            if (data?.[key] !== undefined) {
                 (this as unknown as T)[key] = data[key] as T[keyof T];
             } else if (config.defaultValue !== undefined) {
                 (this as unknown as T)[key] = config.defaultValue;

--- a/src/models/FileModel.ts
+++ b/src/models/FileModel.ts
@@ -261,11 +261,7 @@ export class FileModel<
         if (!this._file) return null;
         const cachedMetadata = this._metadataCache?.getEntry(this._file);
 
-        if (
-            cachedMetadata &&
-            cachedMetadata.metadata &&
-            cachedMetadata.metadata.frontmatter
-        ) {
+        if (cachedMetadata?.metadata?.frontmatter) {
             // Without the deep clone, the data object in the Obsidian Metadata Cache is changed: Problems with dataview..
             const clone = HelperGeneral.deepClone(
                 cachedMetadata.metadata.frontmatter,
@@ -292,7 +288,7 @@ export class FileModel<
         updates: object,
     ): void {
         Object.entries(updates).forEach(([key, value]) => {
-            if (this._yamlKeyMap && this._yamlKeyMap[key]) {
+            if (this._yamlKeyMap?.[key]) {
                 key = this._yamlKeyMap[key];
             }
 


### PR DESCRIPTION
Enhanced code robustness by using optional chaining across multiple files to handle potentially undefined or null values more gracefully. This minimizes runtime errors related to accessing properties on null or undefined objects, ensuring safer and more reliable code execution without additional explicit null checks.