### PR TITLE
Refactoring/di-file-model

### DIFF
--- a/src/classes/Global.ts
+++ b/src/classes/Global.ts
@@ -2,6 +2,7 @@ import { App } from 'obsidian';
 import type { ILogger_, ILogger } from 'src/interfaces/ILogger';
 import type IMetadataCache from 'src/interfaces/IMetadataCache';
 import { Inject } from 'src/libs/DependencyInjection/decorators/Inject';
+import { Register } from 'src/libs/DependencyInjection/decorators/Register';
 import { DIContainer } from 'src/libs/DependencyInjection/DIContainer';
 import Prj from 'src/main';
 import type { IPrjSettings } from 'src/types/PrjSettings';
@@ -9,7 +10,9 @@ import MetadataCache from '../libs/MetadataCache';
 
 /**
  * Represents the global instance for the plugin.
+ * @todo Mark as deprecated.
  */
+@Register('Global', true)
 export default class Global {
     static instance: Global;
 

--- a/src/libs/ProxyHandler/ProxyHandler.ts
+++ b/src/libs/ProxyHandler/ProxyHandler.ts
@@ -1,6 +1,8 @@
+import { ImplementsStatic } from 'src/classes/decorators/ImplementsStatic';
 import { ILogger } from 'src/interfaces/ILogger';
 import { IProxyHandler, IProxyHandler_ } from './interfaces/IProxyHandler';
 import { ObjectPath } from './types/ObjectPath';
+import { Register } from '../DependencyInjection/decorators/Register';
 
 /**
  * A class responsible for
@@ -8,9 +10,9 @@ import { ObjectPath } from './types/ObjectPath';
  * - manage a change object through a delegate function to track changes on the data object.
  * @template T The type of the data object.
  */
-const ProxyHandler_: IProxyHandler_ = class ProxyHandler<T extends object>
-    implements IProxyHandler<T>
-{
+@Register('IProxyHandler_')
+@ImplementsStatic<IProxyHandler_<object>>()
+export class ProxyHandler<T extends object> implements IProxyHandler<T> {
     /**
      * A map to store proxies of objects to reuse them
      * instead of unnecessarily creating new proxies for the same objects.
@@ -327,6 +329,4 @@ const ProxyHandler_: IProxyHandler_ = class ProxyHandler<T extends object>
         this._proxyMap.set(obj, proxy);
         this._reverseProxyMap.set(proxy, new WeakRef(obj));
     }
-};
-
-export { ProxyHandler_ as ProxyHandler };
+}

--- a/src/libs/ProxyHandler/interfaces/IProxyHandler.ts
+++ b/src/libs/ProxyHandler/interfaces/IProxyHandler.ts
@@ -4,13 +4,13 @@ import { ObjectPath } from '../types/ObjectPath';
 /**
  * Constructor Interface for ProxyHandler.
  */
-export interface IProxyHandler_ {
+export interface IProxyHandler_<T extends object> {
     /**
      * Creates an instance of ProxyHandler.
      * @param logger A optional logger instance for logging purposes.
      * @param updateKeyValue A delegate function for updating key-value pairs.
      */
-    new <T extends object>(
+    new (
         logger: ILogger | undefined,
         updateKeyValue: (key: string, value: unknown) => void,
     ): IProxyHandler<T>;

--- a/src/models/DocumentModel.ts
+++ b/src/models/DocumentModel.ts
@@ -59,7 +59,7 @@ export class DocumentModel
                         ? `${wikilinkData.basename}.md`
                         : '';
 
-                    const file = this._metadataCache.getFileByLink(
+                    const file = this._IMetadataCache.getFileByLink(
                         mdFilename,
                         this.file.path,
                     );
@@ -97,7 +97,7 @@ export class DocumentModel
      */
     public async getFileContents(): Promise<string | undefined> {
         try {
-            return this._app.vault.read(this.file);
+            return this._App.vault.read(this.file);
         } catch (error) {
             this._logger?.error(error);
         }
@@ -110,11 +110,11 @@ export class DocumentModel
     public getCorospondingSymbol(): string {
         if (this.data.type?.toString() === 'Metadata') {
             if (this.data.subType === 'Cluster') {
-                return this._pluginSettings.documentSettings.clusterSymbol;
+                return this._IPrjSettings.documentSettings.clusterSymbol;
             } else if (this.data.hide) {
-                return this._pluginSettings.documentSettings.hideSymbol;
+                return this._IPrjSettings.documentSettings.hideSymbol;
             } else {
-                return this._pluginSettings.documentSettings.symbol;
+                return this._IPrjSettings.documentSettings.symbol;
             }
         }
 
@@ -127,8 +127,8 @@ export class DocumentModel
      * E.g. `Input` if the document is addressed to the user or `Output` if it comes from the user. Otherwise `null`.
      */
     public getInputOutputState(): null | 'Input' | 'Output' {
-        const username = this._pluginSettings.user.name;
-        const shortUsername = this._pluginSettings.user.shortName;
+        const username = this._IPrjSettings.user.name;
+        const shortUsername = this._IPrjSettings.user.shortName;
 
         if (this.data && (this.data.sender || this.data.recipient)) {
             if (
@@ -158,7 +158,7 @@ export class DocumentModel
 
         const fileLinkData = new Wikilink(this.data.file);
 
-        const file = this._metadataCache.getFileByLink(
+        const file = this._IMetadataCache.getFileByLink(
             fileLinkData.filename ?? '',
             this.file.path,
         );
@@ -186,7 +186,7 @@ export class DocumentModel
     ): string | undefined {
         if (!file || !(file instanceof TFile)) return;
 
-        const linktext = this._global.app.metadataCache.fileToLinktext(
+        const linktext = this._App.metadataCache.fileToLinktext(
             file,
             path ? path : this.file.path,
         );

--- a/src/models/FileModel.ts
+++ b/src/models/FileModel.ts
@@ -11,7 +11,6 @@ import type {
 import type { IPrjSettings } from 'src/types/PrjSettings';
 import PrjBaseData from './Data/PrjBaseData';
 import { TransactionModel } from './TransactionModel';
-import Global from '../classes/Global';
 import { YamlKeyMap } from '../types/YamlKeyMap';
 
 /**
@@ -20,12 +19,6 @@ import { YamlKeyMap } from '../types/YamlKeyMap';
 export class FileModel<
     T extends PrjBaseData<unknown>,
 > extends TransactionModel<T> {
-    /**
-     * @deprecated This property is deprecated and will be removed in the future.
-     */
-    @Inject('Global')
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    protected _Global!: Global;
     @Inject('IPrjSettings')
     protected _IPrjSettings!: IPrjSettings;
     @Inject('App')

--- a/src/models/NoteModel.ts
+++ b/src/models/NoteModel.ts
@@ -59,7 +59,7 @@ export class NoteModel
      */
     public async getFileContents(): Promise<string | undefined> {
         try {
-            return this._app.vault.read(this.file);
+            return this._App.vault.read(this.file);
         } catch (error) {
             this._logger?.error(error);
         }

--- a/src/models/PrjTaskManagementModel.ts
+++ b/src/models/PrjTaskManagementModel.ts
@@ -71,11 +71,11 @@ export class PrjTaskManagementModel<
     public getCorospondingSymbol(): string {
         switch (this.data.type?.toString()) {
             case 'Topic':
-                return this._pluginSettings.prjSettings.topicSymbol;
+                return this._IPrjSettings.prjSettings.topicSymbol;
             case 'Project':
-                return this._pluginSettings.prjSettings.projectSymbol;
+                return this._IPrjSettings.prjSettings.projectSymbol;
             case 'Task':
-                return this._pluginSettings.prjSettings.taskSymbol;
+                return this._IPrjSettings.prjSettings.taskSymbol;
             default:
                 return 'x-circle';
         }

--- a/src/models/TaskModel.ts
+++ b/src/models/TaskModel.ts
@@ -67,7 +67,7 @@ export class TaskModel extends PrjTaskManagementModel<PrjTaskData> {
     private getRelatedTasks(
         status?: (status: StatusTypes | undefined) => boolean,
     ): TaskModel[] {
-        const filesWithSameTags = this._metadataCache.cache.filter((file) => {
+        const filesWithSameTags = this._IMetadataCache.cache.filter((file) => {
             const fileTags = new Tags(file.metadata?.frontmatter?.tags);
             const thisTags = this.data.tags;
 
@@ -118,7 +118,7 @@ export class TaskModel extends PrjTaskManagementModel<PrjTaskData> {
 
         const date = HelperGeneral.formatDate(
             history.date,
-            this._pluginSettings.dateFormat,
+            this._IPrjSettings.dateFormat,
         );
 
         const newFileName = Path.sanitizeFilename(


### PR DESCRIPTION
Refactor: Move to DI and update class decorators

- Applied dependency injection for `Global`, `App`, `IMetadataCache`, `IProxyHandler_`, and `IPrjSettings` across various classes (`DocumentModel`, `FileModel`, `TaskModel`, etc.).
- Added and utilized new decorators `@Register` and `@ImplementsStatic` for better class management and static implementation enforcement.
- Removed deprecated direct initialization of dependencies and replaced with DI approaches for cleaner and scalable architecture.
- Updated references to injected properties conforming to new injection-based property names (e.g., `_pluginSettings` to `_IPrjSettings`).

Eliminated the deprecated 'Global' property from the FileModel class to clean up the code and reduce maintenance of unused dependencies. Additionally, removed the associated import statement. This simplification prepares the code for future updates and aligns with best practices.