### PR TITLE
Refactor tag method for consistency

### DIFF
--- a/src/libs/BlockRenderComponents/DocumentBlockRenderComponent.ts
+++ b/src/libs/BlockRenderComponents/DocumentBlockRenderComponent.ts
@@ -365,7 +365,7 @@ export default class DocumentBlockRenderComponent extends TableBlockRenderCompon
         GeneralComponents.createCellTags(
             tags,
             this._component,
-            documentModel.data.tags?.toStringArray() ?? [],
+            documentModel.data.tags?.primitiveOf() ?? [],
         );
 
         const hide = this.getHideState(documentModel, undefined);

--- a/src/libs/BlockRenderComponents/NoteBlockRenderComponent.ts
+++ b/src/libs/BlockRenderComponents/NoteBlockRenderComponent.ts
@@ -272,7 +272,7 @@ export default class NoteBlockRenderComponent extends TableBlockRenderComponent<
         GeneralComponents.createCellTags(
             tags,
             this._component,
-            noteModel.data.tags?.toStringArray() ?? [],
+            noteModel.data.tags?.primitiveOf() ?? [],
         );
 
         const row = {

--- a/src/libs/BlockRenderComponents/ProjectBlockRenderComponent.ts
+++ b/src/libs/BlockRenderComponents/ProjectBlockRenderComponent.ts
@@ -362,7 +362,7 @@ export default class ProjectBlockRenderComponent extends TableBlockRenderCompone
         GeneralComponents.createCellTags(
             tags,
             this._component,
-            model.data.tags?.toStringArray() ?? [],
+            model.data.tags?.primitiveOf() ?? [],
         );
 
         const hide = this.getHideState(model, this._settings.maxDocuments);

--- a/src/libs/Modals/BaseModalForm.ts
+++ b/src/libs/Modals/BaseModalForm.ts
@@ -104,7 +104,7 @@ export default abstract class BaseModalForm {
         const activeFileTags = new Tags(undefined);
         activeFileTags.loadTagsFromFile(activeFile);
 
-        const tags: string[] = activeFileTags.toStringArray();
+        const tags: string[] = activeFileTags.primitiveOf();
 
         return tags;
     }

--- a/src/libs/Tags/Tags.ts
+++ b/src/libs/Tags/Tags.ts
@@ -128,7 +128,7 @@ export class Tags implements ITags {
      */
     private normalizeToTags(tag: unknown): ITag[] {
         if (tag instanceof Tags) {
-            return tag.toStringArray().map((t) => this.createTag(t));
+            return tag.primitiveOf().map((t) => this.createTag(t));
         } else if (tag instanceof this._ITag) {
             return [this.createTag(tag.value)];
         } else if (Array.isArray(tag)) {
@@ -188,14 +188,6 @@ export class Tags implements ITags {
     }
 
     /**
-     * Returns all tags.
-     * @returns All tags as an array of strings.
-     */
-    public toStringArray(): string[] {
-        return this._tags.map((tag) => tag.toString());
-    }
-
-    /**
      * Returns the number of tags.
      */
     public get length(): number {
@@ -248,7 +240,7 @@ export class Tags implements ITags {
      * @returns Whether any tag from `tags` is a **substring** of any tag in the instance's tags array
      */
     public contains(tags: ITags): boolean {
-        const _tagsToCheck = tags.toStringArray();
+        const _tagsToCheck = tags.primitiveOf();
 
         return _tagsToCheck.some((tagToCheck) =>
             this._tags.some((tagToBeChecked) =>

--- a/src/libs/Tags/__tests__/Tags.test.ts
+++ b/src/libs/Tags/__tests__/Tags.test.ts
@@ -122,7 +122,7 @@ describe('Tags', () => {
         DIContainer.getInstance().register('ILogger_', undefined);
 
         const tagsArray = new Tags(undefined);
-        expect(tagsArray.toStringArray()).toEqual([]);
+        expect(tagsArray.primitiveOf()).toEqual([]);
         expect(tagsArray.length).toBe(0);
     });
 
@@ -130,7 +130,7 @@ describe('Tags', () => {
         DIContainer.getInstance().register('ILogger_', undefined);
 
         const tagsArray = new Tags('tag1');
-        expect(tagsArray.toStringArray()).toEqual(['tag1']);
+        expect(tagsArray.primitiveOf()).toEqual(['tag1']);
         expect(tagsArray.length).toBe(1);
     });
 
@@ -138,13 +138,13 @@ describe('Tags', () => {
         DIContainer.getInstance().register('ILogger_', undefined);
 
         const tagsArray = new Tags(['tag1', 'tag2']);
-        expect(tagsArray.toStringArray()).toEqual(['tag1', 'tag2']);
+        expect(tagsArray.primitiveOf()).toEqual(['tag1', 'tag2']);
         expect(tagsArray.length).toBe(2);
     });
 
     test('should initialize with undefined tags', () => {
         const tagsArray = new Tags(undefined);
-        expect(tagsArray.toStringArray()).toEqual([]);
+        expect(tagsArray.primitiveOf()).toEqual([]);
         expect(tagsArray.length).toBe(0);
     });
 
@@ -152,14 +152,14 @@ describe('Tags', () => {
     test('should add a single tag that does not exist', () => {
         const tagsArray = new Tags([]);
         tagsArray.add('tag1');
-        expect(tagsArray.toStringArray()).toEqual(['tag1']);
+        expect(tagsArray.primitiveOf()).toEqual(['tag1']);
         expect(tagsArray.length).toBe(1);
     });
 
     test('should not add a single tag that already exists', () => {
         const tagsArray = new Tags(['tag1']);
         tagsArray.add('tag1');
-        expect(tagsArray.toStringArray()).toEqual(['tag1']);
+        expect(tagsArray.primitiveOf()).toEqual(['tag1']);
         expect(tagsArray.length).toBe(1);
 
         expect(MockLogger.warn).toHaveBeenCalledWith(
@@ -170,14 +170,14 @@ describe('Tags', () => {
     test('should add multiple tags', () => {
         const tagsArray = new Tags([]);
         tagsArray.add(['tag1', 'tag2']);
-        expect(tagsArray.toStringArray()).toEqual(['tag1', 'tag2']);
+        expect(tagsArray.primitiveOf()).toEqual(['tag1', 'tag2']);
         expect(tagsArray.length).toBe(2);
     });
 
     test('should not add existing tags when adding multiple tags', () => {
         const tagsArray = new Tags(['tag1']);
         tagsArray.add(['tag1', 'tag2']);
-        expect(tagsArray.toStringArray()).toEqual(['tag1', 'tag2']);
+        expect(tagsArray.primitiveOf()).toEqual(['tag1', 'tag2']);
         expect(tagsArray.length).toBe(2);
 
         expect(MockLogger.warn).toHaveBeenCalledWith(
@@ -194,7 +194,7 @@ describe('Tags', () => {
     test('should remove an existing tag', () => {
         const tagsArray = new Tags(['tag1']);
         tagsArray.remove(tagsArray.value[0]);
-        expect(tagsArray.toStringArray()).toEqual([]);
+        expect(tagsArray.primitiveOf()).toEqual([]);
         expect(tagsArray.length).toBe(0);
     });
 
@@ -203,7 +203,7 @@ describe('Tags', () => {
 
         const nonExistingTag = new MockTagClass('tag2');
         tagsArray.remove(nonExistingTag);
-        expect(tagsArray.toStringArray()).toEqual(['tag1']);
+        expect(tagsArray.primitiveOf()).toEqual(['tag1']);
         expect(tagsArray.length).toBe(1);
         expect(MockLogger.warn).toHaveBeenCalledWith("Tag 'tag2' not found.");
     });
@@ -212,7 +212,7 @@ describe('Tags', () => {
         DIContainer.getInstance().register('ILogger_', undefined);
 
         const tagsArray = new Tags(['tag1', 'tag2']);
-        expect(tagsArray.toStringArray()).toEqual(['tag1', 'tag2']);
+        expect(tagsArray.primitiveOf()).toEqual(['tag1', 'tag2']);
     });
 
     test('should return all tags as a comma-separated string', () => {
@@ -244,7 +244,7 @@ describe('Tags', () => {
     // Additional Tests
     test('should not add duplicate tags when initialized with an array containing duplicates', () => {
         const tagsArray = new Tags(['tag1', 'tag1', 'tag2']);
-        expect(tagsArray.toStringArray()).toEqual(['tag1', 'tag2']);
+        expect(tagsArray.primitiveOf()).toEqual(['tag1', 'tag2']);
         expect(tagsArray.length).toBe(2);
     });
 
@@ -253,7 +253,7 @@ describe('Tags', () => {
 
         const tagToRemove = new MockTagClass('tag1');
         tagsArray.remove(tagToRemove);
-        expect(tagsArray.toStringArray()).toEqual([]);
+        expect(tagsArray.primitiveOf()).toEqual([]);
         expect(tagsArray.length).toBe(0);
         expect(MockLogger.warn).toHaveBeenCalledWith("Tag 'tag1' not found.");
     });
@@ -263,7 +263,7 @@ describe('Tags', () => {
 
         const tagsArray = new Tags(['tag1']);
         tagsArray.add('tag1');
-        expect(tagsArray.toStringArray()).toEqual(['tag1']);
+        expect(tagsArray.primitiveOf()).toEqual(['tag1']);
         expect(tagsArray.length).toBe(1);
         // Since no logger is provided, there should be no logs
     });
@@ -275,7 +275,7 @@ describe('Tags', () => {
 
         const nonExistingTag = new MockTagClass('tag2');
         tagsArray.remove(nonExistingTag);
-        expect(tagsArray.toStringArray()).toEqual(['tag1']);
+        expect(tagsArray.primitiveOf()).toEqual(['tag1']);
         expect(tagsArray.length).toBe(1);
         // Since no logger is provided, there should be no logs
     });
@@ -322,7 +322,7 @@ describe('Tags', () => {
         const tagsArray = new Tags([]);
         const result = tagsArray.loadTagsFromFile(mockFile);
         expect(result).toBe(true);
-        expect(tagsArray.toStringArray()).toEqual(['tag1', 'tag2']);
+        expect(tagsArray.primitiveOf()).toEqual(['tag1', 'tag2']);
     });
 
     test('should log warning if no metadata in file', () => {
@@ -332,7 +332,7 @@ describe('Tags', () => {
         const tagsArray = new Tags([]);
         const result = tagsArray.loadTagsFromFile(mockFile);
         expect(result).toBe(false);
-        expect(tagsArray.toStringArray()).toEqual([]);
+        expect(tagsArray.primitiveOf()).toEqual([]);
 
         expect(MockLogger.warn).toHaveBeenCalledWith(
             'No metadata found in the file.',
@@ -343,7 +343,7 @@ describe('Tags', () => {
         const tagsArray = new Tags([]);
         const result = tagsArray.loadTagsFromFile(undefined);
         expect(result).toBe(false);
-        expect(tagsArray.toStringArray()).toEqual([]);
+        expect(tagsArray.primitiveOf()).toEqual([]);
         expect(MockLogger.warn).toHaveBeenCalledWith('No file provided.');
     });
 

--- a/src/libs/Tags/interfaces/ITags.ts
+++ b/src/libs/Tags/interfaces/ITags.ts
@@ -55,12 +55,6 @@ export interface ITags
     remove(tag: ITag): boolean;
 
     /**
-     * Returns all tags.
-     * @returns All tags as an array of strings.
-     */
-    toStringArray(): string[];
-
-    /**
      * Returns the number of tags.
      */
     get length(): number;
@@ -132,4 +126,9 @@ export interface ITags
      * @returns Whether the tags were loaded.
      */
     loadTagsFromFile(file: TFile | undefined): boolean;
+
+    /**
+     * @inheritdoc
+     */
+    primitiveOf(): string[];
 }

--- a/src/models/DocumentModel.ts
+++ b/src/models/DocumentModel.ts
@@ -424,7 +424,7 @@ export class DocumentModel
         let tagFolder: string | undefined = undefined;
         let specialTagFolder: string | undefined = undefined;
 
-        const tagArray = document.data.tags?.toStringArray() ?? [];
+        const tagArray = document.data.tags?.primitiveOf() ?? [];
 
         // Tag Folder
         // `document.data.tags` is an Array, search for the first tag that matches a custom tag folder


### PR DESCRIPTION
Replaced usage of `toStringArray` with `primitiveOf` across multiple components to standardize tag handling. Removed `toStringArray` method from `Tags` class and updated related tests to reflect this change. Ensures a consistent approach to retrieving primitive tag arrays, simplifying future maintenance and reducing potential for bugs.